### PR TITLE
Add a use case for the control channel for audio devices.

### DIFF
--- a/use-cases.html
+++ b/use-cases.html
@@ -139,6 +139,26 @@
             <a href="http://en.wikipedia.org/wiki/IBeacon">iBeacon</a> and <a href="https://www.paypal.com/webapps/mpp/beacon">PayPal Beacons</a>
             are particularly famous examples.
         </section>
+
+        <section id="usecase_audio_control">
+          <h2>Audio control</h2>
+
+          <p>
+            The process of playing audio to a Bluetooth speaker or
+            recording from a Bluetooth microphone should be handled by a combination of the
+            <code><a href="http://dev.w3.org/2011/webrtc/editor/getusermedia.html#enumerating-devices">navigator.mediaDevices</a></code> and
+            <a href="http://webaudio.github.io/web-audio-api/#AudioDestinationNode">WebAudio</a> APIs.
+            Websites shouldn't need to deal with the Bluetooth audio protocol
+            in order to simply play or record sound.
+            However, speakers and microphones can also expose a metadata channel,
+            for example to control hardware volume, balance,
+            or even report the position of the user's head.
+
+          <p>
+            A user should be able to pair a device to a site in a single interaction,
+            rather than needing separate actions for each API the site wants to use.
+            The site should be able to associate representations of the same device
+            across multiple APIs.
       </section>
 
       <section id="requirements_section">


### PR DESCRIPTION
@carybran, how's this look? Are there any better examples I should include?

Demo at https://rawgit.com/WebBluetoothCG/web-bluetooth/audio-use-case/use-cases.html#usecase_audio_control

Note that I'm also adding support for GATT-over-BR/EDR in #27, which should make this use case work better for your devices.
