### PR TITLE
Clarify link to requestDevice algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -187,8 +187,8 @@
 
         <p>
           To help ensure that only the entity the user approved for access actually has access,
-          this specification requires that only
-          <a href="#requestDevice-secure-origin">secure origins</a> can access Bluetooth devices.
+          this specification requires that only secure origins can access Bluetooth devices
+          (<a href="#requestDevice-secure-origin">requestDevice</a>).
       </section>
 
       <section class="informative">


### PR DESCRIPTION
Previous wording linked 'secure origin' which is only an indirectly
defined term. Link text of 'requestDevice' orients reader that
the link is to a portion of the requestDevice steps.
