### PR TITLE
Make deviceClass, vendorID, productID, productVersion "unsigned long".

### DIFF
--- a/index.html
+++ b/index.html
@@ -563,22 +563,22 @@
           <dt>readonly attribute DOMString? name</dt>
           <dd>The human-readable name of the device.</dd>
 
-          <dt>readonly attribute long? deviceClass</dt>
+          <dt>readonly attribute unsigned long? deviceClass</dt>
           <dd>The class of the device, a bit-field defined by [[!BLUETOOTH-ASSIGNED-BASEBAND]].</dd>
 
           <dt>readonly attribute VendorIDSource? vendorIDSource</dt>
           <dd>The Vendor ID Source field
           in the <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.pnp_id.xml">pnp_id</a> characteristic
           in the <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.device_information.xml">device_information</a> service.</dd>
-          <dt>readonly attribute long? vendorID</dt>
+          <dt>readonly attribute unsigned long? vendorID</dt>
           <dd>The 16-bit Vendor ID field
           in the <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.pnp_id.xml">pnp_id</a> characteristic
           in the <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.device_information.xml">device_information</a> service.</dd>
-          <dt>readonly attribute long? productID</dt>
+          <dt>readonly attribute unsigned long? productID</dt>
           <dd>The 16-bit Product ID field
           in the <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.pnp_id.xml">pnp_id</a> characteristic
           in the <a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.device_information.xml">device_information</a> service.</dd>
-          <dt>readonly attribute long? productVersion</dt>
+          <dt>readonly attribute unsigned long? productVersion</dt>
           <dd>
             The 16-bit Product Version field in the
             <a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.pnp_id.xml">pnp_id</a>


### PR DESCRIPTION
Resolves #62, making attributes unsigned.