### PR TITLE
Fix #39: Drop the tree navigators that take a sequence of UUIDs.

### DIFF
--- a/index.html
+++ b/index.html
@@ -626,21 +626,12 @@
             </ol>
           </dd>
 
-          <dt>Promise&lt;sequence&lt;BluetoothGATTService>> getPrimaryServices()</dt>
+          <dt>Promise&lt;sequence&lt;BluetoothGATTService>>
+              getPrimaryServices(optional BluetoothServiceUuid service)</dt>
           <dd>
             <a>Query the Bluetooth cache</a> for the primary GATT services on the remote device
-            whose UUIDs are in the <a>allowed services list</a> for this device and origin,
-            and return the result.
-          </dd>
-
-          <dt>Promise&lt;sequence&lt;BluetoothGATTService>> getPrimaryServices(BluetoothServiceUuid service)</dt>
-          <dd>Returns <code>this.getPrimaryServices([service])</code></dd>
-
-          <dt>Promise&lt;sequence&lt;BluetoothGATTService>> getPrimaryServices(sequence&lt;BluetoothServiceUuid> services)</dt>
-          <dd>
-            <a>Query the Bluetooth cache</a> for the primary GATT services on the remote device
-            whose UUIDs are in both <var>services</var>
-            and the <a>allowed services list</a> for this device and origin,
+            whose UUIDs are in the <a>allowed services list</a> for this device and origin
+            and, if <var>service</var> is present, whose UUIDs are equal to <var>service</var>,
             and return the result.
           </dd>
         </dl>
@@ -811,19 +802,15 @@
             </ol>
           </dd>
 
-          <dt>Promise&lt;sequence&lt;BluetoothGATTCharacteristic>> getCharacteristics()</dt>
+          <dt>Promise&lt;sequence&lt;BluetoothGATTCharacteristic>>
+              getCharacteristics(optional BluetoothCharacteristicUuid characteristic)</dt>
           <dd>
-            <a>Query the Bluetooth cache</a> for the GATT characteristics within this Service
+            If <var>characteristic</var> is present,
+            <a>query the Bluetooth cache</a> for the GATT characteristics within this Service
+            with UUIDs equal to <var>characteristic</var>,
             and return the result.
-          </dd>
-          <dt>Promise&lt;sequence&lt;BluetoothGATTCharacteristic>> getCharacteristics(BluetoothCharacteristicUuid characteristic)</dt>
-          <dd>
-            Returns <code>this.getCharacteristics([characteristic])</code>
-          </dd>
-          <dt>Promise&lt;sequence&lt;BluetoothGATTCharacteristic>> getCharacteristics(sequence&lt;BluetoothCharacteristicUuid> characteristics)</dt>
-          <dd>
-            <a>Query the Bluetooth cache</a> for the GATT characteristics within this Service
-            with UUIDs in <var>characteristics</var>,
+            Otherwise, <a>query the Bluetooth cache</a> for
+            all of the GATT characteristics within this Service
             and return the result.
           </dd>
 
@@ -844,19 +831,15 @@
             </ol>
           </dd>
 
-          <dt>Promise&lt;sequence&lt;BluetoothGATTService>> getIncludedServices()</dt>
+          <dt>Promise&lt;sequence&lt;BluetoothGATTService>>
+              getIncludedServices(optional BluetoothServiceUuid service)</dt>
           <dd>
-            <a>Query the Bluetooth cache</a> for the GATT included services within this Service,
+            If <var>service</var> is present,
+            <a>query the Bluetooth cache</a> for the GATT Included Services within this Service
+            with UUIDs equal to <var>service</var>,
             and return the result.
-          </dd>
-          <dt>Promise&lt;sequence&lt;BluetoothGATTService>> getIncludedServices(BluetoothServiceUuid service)</dt>
-          <dd>
-            Returns <code>this.getIncludedServices([service])</code>
-          </dd>
-          <dt>Promise&lt;sequence&lt;BluetoothGATTService>> getIncludedServices(sequence&lt;BluetoothServiceUuid> services)</dt>
-          <dd>
-            <a>Query the Bluetooth cache</a> for the GATT included services within this Service
-            with UUIDs in <var>services</var>,
+            Otherwise, <a>query the Bluetooth cache</a> for
+            all of the GATT Included Services within this Service
             and return the result.
           </dd>
         </dl>
@@ -913,17 +896,15 @@
             </ol>
           </dd>
 
-          <dt>Promise&lt;sequence&lt;BluetoothGATTDescriptor>> getDescriptors()</dt>
+          <dt>Promise&lt;sequence&lt;BluetoothGATTDescriptor>>
+              getDescriptors(optional BluetoothDescriptorUuid descriptor)</dt>
           <dd>
-            <a>Query the Bluetooth cache</a> for the GATT descriptors within this Characteristic,
+            If <var>descriptor</var> is present,
+            <a>query the Bluetooth cache</a> for the GATT descriptors within this Characteristic
+            with UUIDs equal to <var>descriptor</var>,
             and return the result.
-          </dd>
-          <dt>Promise&lt;sequence&lt;BluetoothGATTDescriptor>> getDescriptors(BluetoothDescriptorUuid descriptor)</dt>
-          <dd>Returns <code>this.getDescriptors([descriptor])</code></dd>
-          <dt>Promise&lt;sequence&lt;BluetoothGATTDescriptor>> getDescriptors(sequence&lt;BluetoothDescriptorUuid> descriptors)</dt>
-          <dd>
-            <a>Query the Bluetooth cache</a> for the GATT descriptors within this Characteristic
-            with UUIDs in <var>descriptors</var>,
+            Otherwise, <a>query the Bluetooth cache</a> for
+            all of the GATT descriptors within this Characteristic
             and return the result.
           </dd>
 

--- a/index.html
+++ b/index.html
@@ -805,12 +805,10 @@
           <dt>Promise&lt;sequence&lt;BluetoothGATTCharacteristic>>
               getCharacteristics(optional BluetoothCharacteristicUuid characteristic)</dt>
           <dd>
-            If <var>characteristic</var> is present,
-            <a>query the Bluetooth cache</a> for the GATT characteristics within this Service
-            with UUIDs equal to <var>characteristic</var>,
-            and return the result.
-            Otherwise, <a>query the Bluetooth cache</a> for
-            all of the GATT characteristics within this Service
+            <a>Query the Bluetooth cache</a> for
+            the GATT characteristics that are within this Service and,
+            if <var>characteristic</var> is present,
+            that have UUIDs equal to <var>characteristic</var>,
             and return the result.
           </dd>
 
@@ -834,12 +832,10 @@
           <dt>Promise&lt;sequence&lt;BluetoothGATTService>>
               getIncludedServices(optional BluetoothServiceUuid service)</dt>
           <dd>
-            If <var>service</var> is present,
-            <a>query the Bluetooth cache</a> for the GATT Included Services within this Service
-            with UUIDs equal to <var>service</var>,
-            and return the result.
-            Otherwise, <a>query the Bluetooth cache</a> for
-            all of the GATT Included Services within this Service
+            <a>Query the Bluetooth cache</a> for
+            the GATT Included Services that are within this Service and,
+            if <var>service</var> is present,
+            that have UUIDs equal to <var>service</var>,
             and return the result.
           </dd>
         </dl>
@@ -899,12 +895,10 @@
           <dt>Promise&lt;sequence&lt;BluetoothGATTDescriptor>>
               getDescriptors(optional BluetoothDescriptorUuid descriptor)</dt>
           <dd>
-            If <var>descriptor</var> is present,
-            <a>query the Bluetooth cache</a> for the GATT descriptors within this Characteristic
-            with UUIDs equal to <var>descriptor</var>,
-            and return the result.
-            Otherwise, <a>query the Bluetooth cache</a> for
-            all of the GATT descriptors within this Characteristic
+            <a>Query the Bluetooth cache</a> for
+            the GATT descriptors that are within this Characteristic and,
+            if <var>descriptor</var> is present,
+            that have UUIDs equal to <var>descriptor</var>,
             and return the result.
           </dd>
 


### PR DESCRIPTION
This also stops the spec from using overloading.

@jracle @scheib, let me know if this matches how you expected #39 to be resolved. Demo at https://rawgit.com/jyasskin/web-bluetooth-1/drop-sequence-uuid-getters/index.html.