### PR TITLE
Fix #61: Be clear that the UA must show a prompt even if no devices were found.

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,14 +322,17 @@
             <li>
               <a>Scan for devices</a> with
               the union of all <code>services</code> sequences in <code><var>filters</var></code>
-              as the <var>set of <a>Service</a> UUIDs</var>
+              as the <var>set of <a>Service</a> UUIDs</var>,
+              and let <var>scanResult</var> be the result.
             </li>
             <li>
-              Remove devices from the result of the scan if
+              Remove devices from <var>scanResult</var> if
               they do not <a title="matches a filter">match a filter</a>
               in <code><var>filters</var></code>.
+            </li>
             <li>
-              Display a prompt to the user requesting that the user specify some devices from the result of the scan.
+              Even if <var>scanResult</var> is empty,
+              display a prompt to the user requesting that the user select a device from it.
               The UA SHOULD show the user the human-readable name of each device.
               If this name is not available because the UA's Bluetooth system doesn't support privacy-enabled scans,
               the UA SHOULD allow the user to indicate interest and then perform a privacy-disabled scan to retrieve the name.


### PR DESCRIPTION
Demo at [https://rawgit.com/jyasskin/web-bluetooth-1/empty-scan-result/index.html](https://rawgit.com/jyasskin/web-bluetooth-1/empty-scan-result/index.html#widl-BluetoothDiscovery-requestDevice-Promise-BluetoothDevice--sequence-BluetoothScanFilter--filters-RequestDeviceOptions-options)