### PR TITLE
Update the Community Group summary with github and spec links.

### DIFF
--- a/cg-summary.md
+++ b/cg-summary.md
@@ -5,7 +5,8 @@ This is the text that appears at the top of https://www.w3.org/community/web-blu
 # WEB BLUETOOTH COMMUNITY GROUP
 
 Bluetooth is a standard for short-range wireless communication between devices.
-This group is developing a specification for Bluetooth APIs to
+This group is developing a
+[specification for Bluetooth APIs](https://webbluetoothcg.github.io/web-bluetooth/) to
 allow websites to communicate with devices in a secure and privacy-preserving way.
 In particular the web Bluetooth API focuses on
 minimizing the device attack surface exposed to malicious websites,
@@ -13,3 +14,8 @@ possibly by removing access to
 some existing Bluetooth features that are hard to implement securely.
 Further, the API takes the approach of a user interface to
 select and approve access to devices as opposed to using certification and installation.
+
+Most of our activity happens in our
+[GitHub repository](https://github.com/WebBluetoothCG/web-bluetooth),
+with supporting code in adjacent repositories in the
+[WebBluetoothCG GitHub organization](https://github.com/WebBluetoothCG).


### PR DESCRIPTION
@marcoscaceres @anssiko: Here's an attempt to help people who land on https://www.w3.org/community/web-bluetooth/ find their way to the places the spec is actually developed. I also had team-community-process@w3c add the Github link to the Tools section.

Once this PR lands, with any other changes folks think are a good idea, I'll ask the W3C folks to update the CG page.