### PR TITLE
Changed broken link

### DIFF
--- a/use-cases.html
+++ b/use-cases.html
@@ -93,7 +93,7 @@
           <p>Other devices include:
           <ul>
             <li>
-              <a href="http://www.cellphoneshop.net/bikesensor.html">Bicycle cadence sensor</a>
+              <a href="http://amzn.com/B007HOGNLW">Bicycle cadence sensor</a>
               (<a href="https://developer.bluetooth.org/gatt/profiles/Pages/ProfileViewer.aspx?u=org.bluetooth.profile.cycling_speed_and_cadence.xml">standard profile</a>)
             <li><a href="http://www.barcodegiant.com/unitech/part-ms840-subbgc-sg.htm">Barcode scanner</a>
             <li><a href="http://www.bhphotovideo.com/bnh/controller/home?sku=1024990&Q=&is=REG&A=details">BT security tags</a>


### PR DESCRIPTION
Uses Cases 2.1.1.: "Bicycle cadence sensor" link was broken. Changed for a functioning one. Fixes #89 