### PR TITLE
Fix assertion that Peripherals can only receive one connection.

### DIFF
--- a/index.html
+++ b/index.html
@@ -126,9 +126,9 @@
         BTLE defines multiple roles that devices can play.
         The <dfn>Broadcaster</dfn> and <dfn>Observer</dfn> roles are
         for transmitter- and receiver-only applications, respectively.
-        The <dfn>Peripheral</dfn> role is able to receive a single connection.
-        The <dfn>Central</dfn> role supports multiple connections,
-        and is responsible for creating any connections to <a>Peripheral</a> devices.
+        Devices acting in the <dfn>Peripheral</dfn> role can receive connections,
+        and devices acting in the <dfn>Central</dfn> role can connect to <a>Peripheral</a> devices.
+      </p>
 
       <p>
         <dfn>GATT</dfn> further defines <dfn>Client</dfn> and <dfn>Server</dfn> roles,


### PR DESCRIPTION
@g-ortuno @armansito 

I suspect we should rewrite the Introduction to be more explanatory, but this'll fix the immediate issue.