### PR TITLE
Add Implementation Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Documents in this repository
 * [Use Cases and Security Requirements](https://webbluetoothcg.github.io/web-bluetooth/use-cases.html)
 * [Explainer](https://github.com/WebBluetoothCG/web-bluetooth/blob/gh-pages/explainer.md), showing how a site might use this API to satisfy the use cases
 * [Specification](https://webbluetoothcg.github.io/web-bluetooth/)
+* [Implementation Status](implementation-status.md)
 
 Communication
 -------------

--- a/implementation-status.md
+++ b/implementation-status.md
@@ -1,0 +1,19 @@
+# Implementation Status
+This document shows the implementation status of Web Bluetooth on the
+different browsers.
+
+To try out the Web Bluetooth API developers can use the [Android BLE Peripheral
+App](https://github.com/WebBluetoothCG/ble-test-peripheral-android). The
+Peripheral App simulates a BLE peripheral. Developers can connect to
+the simulated BLE peripheral using the Web Bluetooth API to read and write
+characteristics or subscribe to notifications from them.
+
+# Chrome
+Currently working on the implementation under the
+chrome://flags/#enable-experimental-web-platform-features flag.
+
+## [Chrome Apps Polyfill](https://github.com/WebBluetoothCG/chrome-app-polyfill)
+A polyfill for the Web Bluetooth API running inside a Chrome App.
+
+Developers can embed the Polyfill into a Chrome App to get a feel of how the
+Web Bluetooth API will work. Note: Only works on ChromeOS.


### PR DESCRIPTION
Adds an Implementation Status Document that contains browser-specific
information about the current status of Web Bluetooth.

We want a page that we can point developers to when they ask to try out
the Web Bluetooth API.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/webbluetoothcg/web-bluetooth/110)
<!-- Reviewable:end -->
