### PR TITLE
Expose all interfaces with user-visible instances, and make sure they start with "Bluetooth".

### DIFF
--- a/index.html
+++ b/index.html
@@ -444,7 +444,6 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
           sequence&lt;BluetoothServiceUUID> optionalServices = [];
         };
 
-        [NoInterfaceObject]
         interface Bluetooth {
           Promise&lt;BluetoothDevice> requestDevice(RequestDeviceOptions options);
         };
@@ -1191,7 +1190,6 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
           <h2><dfn>BluetoothAdvertisingData</dfn></h2>
 
           <pre class="idl">
-            [NoInterfaceObject]
             interface BluetoothAdvertisingData {
               readonly attribute unsigned short? appearance;
               readonly attribute byte? txPower;
@@ -2129,7 +2127,7 @@ return navigator.bluetooth.requestDevice({
           </p>
 
           <pre class="idl">
-            interface CharacteristicProperties {
+            interface BluetoothCharacteristicProperties {
               readonly attribute boolean broadcast;
               readonly attribute boolean read;
               readonly attribute boolean writeWithoutResponse;


### PR DESCRIPTION
This allows users to add helper functions to their prototypes without getting an
object first. This spec claims the window.Bluetooth* namespace.

I've included `Bluetooth`, the type of `navigator.bluetooth`, for symmetry, even though users can just modify `navigator.bluetooth` directly.

Demo at https://rawgit.com/jyasskin/web-bluetooth-1/expose-the-right-interfaces/index.html.