### PR TITLE
Enforce that canonicalUUID() is called with an in-range alias.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2763,7 +2763,7 @@ return navigator.bluetooth.requestDevice({
             static UUID getCharacteristic((DOMString or unsigned long) name);
             static UUID getDescriptor((DOMString or unsigned long) name);
 
-            static UUID canonicalUUID(unsigned long alias);
+            static UUID canonicalUUID([EnforceRange] unsigned long alias);
           };
 
           typedef (DOMString or unsigned long) BluetoothServiceUUID;


### PR DESCRIPTION
Issue #133 tracks applying this to the other functions taking unsigned long.
This also allows some non-integer arguments, due to WebIDL details.

https://codereview.chromium.org/1210173011/ shows the behavior.