### PR TITLE
Throw NotFoundError when trying to look up a non-existent attribute.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1616,8 +1616,8 @@ return navigator.bluetooth.requestDevice({
           </li>
           <li>
             Return the result of
-            <a>transforming</a> <var>promise</var> with a fulfilment handler that
-            returns <code>null</code> if its argument is empty
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
             or returns the first (only) element of its argument.
           </li>
         </ol>
@@ -1638,7 +1638,13 @@ return navigator.bluetooth.requestDevice({
             on <code>this@[[\representedDevice]]</code>
             whose UUIDs are in <code>this@[[\allowedServices]]</code>
             and, if <var>service</var> is present, whose UUIDs are equal to <var>service</var>,
-            and return the result.
+            and let <var>promise</var> be the result.
+          </li>
+          <li>
+            Return the result of
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
+            or returns its argument.
           </li>
         </ol>
       </section>
@@ -1740,8 +1746,8 @@ return navigator.bluetooth.requestDevice({
           </li>
           <li>
             Return the result of
-            <a>transforming</a> <var>promise</var> with a fulfilment handler that
-            returns <code>null</code> if its argument is empty
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
             or returns the first (only) element of its argument.
           </li>
         </ol>
@@ -1763,7 +1769,13 @@ return navigator.bluetooth.requestDevice({
             the GATT characteristics that are within this Service and,
             if <var>characteristic</var> is present,
             that have UUIDs equal to <var>characteristic</var>,
-            and return the result.
+            and let <var>promise</var> be the result.
+          </li>
+          <li>
+            Return the result of
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
+            or returns its argument.
           </li>
         </ol>
 
@@ -1786,8 +1798,8 @@ return navigator.bluetooth.requestDevice({
           </li>
           <li>
             Return the result of
-            <a>transforming</a> <var>promise</var> with a fulfilment handler that
-            returns <code>null</code> if its argument is empty
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
             or returns the first (only) element of its argument.
           </li>
         </ol>
@@ -1809,7 +1821,13 @@ return navigator.bluetooth.requestDevice({
             the GATT Included Services that are within this Service and,
             if <var>service</var> is present,
             that have UUIDs equal to <var>service</var>,
-            and return the result.
+            and let <var>promise</var> be the result.
+          </li>
+          <li>
+            Return the result of
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
+            or returns its argument.
           </li>
         </ol>
       </section>
@@ -1918,8 +1936,8 @@ return navigator.bluetooth.requestDevice({
           </li>
           <li>
             Return the result of
-            <a>transforming</a> <var>promise</var> with a fulfilment handler that
-            returns <code>null</code> if its argument is empty
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
             or returns the first (only) element of its argument.
           </li>
         </ol>
@@ -1941,7 +1959,13 @@ return navigator.bluetooth.requestDevice({
             the GATT descriptors that are within this Characteristic and,
             if <var>descriptor</var> is present,
             that have UUIDs equal to <var>descriptor</var>,
-            and return the result.
+            and let <var>promise</var> be the result.
+          </li>
+          <li>
+            Return the result of
+            <a>transforming</a> <var>promise</var> with a fulfillment handler that
+            throws a <a>NotFoundError</a> if its argument is empty
+            or returns its argument.
           </li>
         </ol>
 


### PR DESCRIPTION
The common case seems to be navigating a tree with certain attributes expected
to be there, and null checks make that more complicated. It's still possible to
handle optional attributes by catching the exception.

We have less experience with the multi-attribute getters, but I'm doing them
consistently for now.

Fixes #124.

Demo at https://rawgit.com/jyasskin/web-bluetooth-1/throw-for-missing-attributes/index.html. @beaufortfrancois @scheib 