### PR TITLE
Throw an exception if requestDevice() filters include no services

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,16 +531,11 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
 
       <p>
         A device <dfn>matches a filter</dfn> <var>filter</var> if
+        the UA has received advertising data, an <a>extended inquiry response</a>,
+        or a service discovery response indicating that
+        the device supports each of the <a>Service</a> UUIDs
+        included in <code><var>filter</var>.services</code> as a primary (vs included) service.
       </p>
-      <ul>
-        <li><code><var>filter</var>.services</code> is not empty and</li>
-        <li>
-          the UA has received advertising data, an <a>extended inquiry response</a>,
-          or a service discovery response indicating that
-          the device supports each of the <a>Service</a> UUIDs
-          included in <code><var>filter</var>.services</code> as a primary (vs included) service.
-        </li>
-      </ul>
 
       <p class="note">
         The list of Service UUIDs that a device advertises
@@ -578,6 +573,11 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
               For each <var>filter</var> in <code><var>options</var>.filters</code>,
               do the following steps:
               <ol>
+                <li>
+                  If <code><var>filter</var>.services.length === 0</code>,
+                  <a>reject</a> <var>promise</var> with a <a>TypeError</a>
+                  and abort these steps.
+                </li>
                 <li>
                   Let <var>services</var> be
                   <code>Array.prototype.map.call(<var>filter</var>.services,
@@ -3400,6 +3400,8 @@ return navigator.bluetooth.requestDevice({
                    ><dfn><code>Set</code></dfn></a></li>
             <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-typedarray-constructors"
                    ><dfn><code>TypedArray</code></dfn></a></li>
+            <li><a href="http://www.ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror"
+                   ><dfn><code>TypeError</code></dfn></a></li>
           </ul>
         </dd>
         <dt>[[!HTML]]</dt>

--- a/rationale.md
+++ b/rationale.md
@@ -32,6 +32,12 @@ page doesn't filter the devices that appear in the `requestDevice()` dialog,
 users could easily select a device the web page can't use, which is a bad
 experience.
 
+One reason for scanning without service UUID filters is to collect just
+advertising data from several nearby devices. The first version of Web Bluetooth
+is aimed at GATT communication with particular paired devices and doesn't
+support this use case. A subsequent version will most likely include such
+support, likely through a different entry point.
+
 ## Why so many `Get{,All}{Service,Characteristic,Descriptor}()` overloads?
 
 GATT provides two ways of finding primary services:

--- a/rationale.md
+++ b/rationale.md
@@ -24,6 +24,14 @@ This document attempts to explain why various decisions were made the way they w
 * While the <a>Server</a> role can work in a <a>Central</a> device,
   <a>Client</a> is more natural and is required for more use cases.
 
+## Why does `requestDevice()` require non-empty filters?
+
+In order to communicate with a device, that device needs to support a GATT
+Service that the web page understands and has permission to access. If the web
+page doesn't filter the devices that appear in the `requestDevice()` dialog,
+users could easily select a device the web page can't use, which is a bad
+experience.
+
 ## Why so many `Get{,All}{Service,Characteristic,Descriptor}()` overloads?
 
 GATT provides two ways of finding primary services:


### PR DESCRIPTION
instead of silently returning no devices.

Fixes #142.

Demo at https://rawgit.com/jyasskin/web-bluetooth-1/loud-empty-filters/index.html. @beaufortfrancois @scheib 