### PR TITLE
Rename BluetoothDevice.instanceID to BluetoothDevice.id.

### DIFF
--- a/index.html
+++ b/index.html
@@ -946,7 +946,7 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
           };
 
           interface BluetoothDevice {
-            readonly attribute DOMString instanceID;
+            readonly attribute DOMString id;
             readonly attribute DOMString? name;
             readonly attribute BluetoothAdvertisingData adData;
             readonly attribute unsigned long? deviceClass;
@@ -966,7 +966,7 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
 
         <div class="note" title="BluetoothDevice attributes">
           <p>
-            <dfn>instanceID</dfn> uniquely identifies a device to the extent that
+            <dfn>id</dfn> uniquely identifies a device to the extent that
             the UA can determine that two Bluetooth connections are to the same device.
             It is computed as the <a>device id</a> in <a>add an allowed Bluetooth device</a>.
             This ID can't be used to match a device across origins
@@ -1065,7 +1065,7 @@ href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicV
                 that is the <a>same device</a> as <var>device</var>.
                 If there is no such key,
                 <a>resolve</a> <var>promise</var> with a <a>SecurityError</a> and abort these steps.
-                Otherwise, initialize <code><var>result</var>.instanceID</code>
+                Otherwise, initialize <code><var>result</var>.id</code>
                 to the <a>device id</a> this key maps to,
                 and initialize an internal
                 <code><var>result</var>@[[\allowedServices]]</code> field


### PR DESCRIPTION
This avoids questions about how to capitalize "ID". There aren't any other uses
of instanceID left, since #113 removed them, so we don't need this spelling to
be consistent.

Fixes #139.

Demo at https://rawgit.com/jyasskin/web-bluetooth-1/rename-instanceid/index.html.