### PR TITLE
Start a specification for test-only APIs used in the Web Bluetooth tests.

### DIFF
--- a/tests/index.bs
+++ b/tests/index.bs
@@ -1,14 +1,13 @@
 <pre class='metadata'>
 Title: Testing Web Bluetooth
+Group: web-bluetooth-cg
 Status: CG-DRAFT
 ED: https://webbluetoothcg.github.io/web-bluetooth/tests
 Shortname: testing-web-bluetooth
 Level: 1
 Editor: See contributors on GitHub, , https://github.com/WebBluetoothCG/web-bluetooth/graphs/contributors
 Abstract: This document describes functions used in testing the Web Bluetooth API.
-
-Group: web-bluetooth-cg
-
+Status Text: <strong class="advisement">This specification does not yet reflect the consensus of the Web Bluetooth CG. It is presented by the Chromium developers in the hope that other implementers will find it useful. It may be withdrawn if they don't.</strong>
 Markup Shorthands: css no
 Link Defaults: html (dfn) trusted event/the body element
 Link Defaults: web-bluetooth (dfn) valid uuid

--- a/tests/index.bs
+++ b/tests/index.bs
@@ -34,6 +34,9 @@ spec: BLUETOOTH-ASSIGNED
     type: enum; urlPrefix: https://developer.bluetooth.org/gatt/
         urlPrefix: characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.
             text: org.bluetooth.characteristic.gap.device_name; url: gap.device_name.xml#
+        urlPrefix: descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.
+            text: org.bluetooth.descriptor.gatt.characteristic_user_description; url: gatt.characteristic_user_description.xml#
+            text: org.bluetooth.descriptor.gatt.characteristic_extended_properties; url: gatt.characteristic_extended_properties.xml#
         urlPrefix: services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.
             text: org.bluetooth.service.battery_service; url: battery_service.xml#
             text: org.bluetooth.service.glucose; url: glucose.xml#
@@ -114,12 +117,17 @@ UA's Bluetooth system to respond depending on the {{dataSetName}}:
 :: No devices are nearby.
 : <code>"FailStartDiscoveryAdapter"</code>
 :: The UA fails to start a scan for devices.
+: <code>"FailStopDiscoveryAdapter"</code>
+:: Behaves like a GenericAccessAdapter, but the UA fails to stop the scan for
+    devices.
 : <code>"GlucoseHeartRateAdapter"</code>
 :: The UA discovers a <a>HeartRateDevice</a> and then a <a>GlucoseDevice</a>.
 : <code>"MissingServiceGenericAccessAdapter"</code>
 :: The UA discovers a <a>MissingServiceGenericAccessDevice</a>.
 : <code>"MissingCharacteristicGenericAccessAdapter"</code>
 :: The UA discovers a <a>MissingCharacteristicGenericAccessDevice</a>.
+: <code>"MissingDescriptorGenericAccessAdapter"</code>
+:: The UA discovers a <a>MissingDescriptorGenericAccessDevice</a>.
 : <code>"GenericAccessAdapter"</code>
 :: The UA discovers a <a>GenericAccessDevice</a>.
 : <code>"FailingGATTOperationsAdapter"</code>
@@ -162,7 +170,7 @@ In addition to the properties of a <a>MissingServiceGenericAccessDevice</a>, its
 GATT Server contains a primary {{org.bluetooth.service.generic_access}} service.
 This service contains no characteristics.
 
-<h4 dfn-type="dfn">GenericAccessDevice</h4>
+<h4 dfn-type="dfn">MissingDescriptorGenericAccessDevice</h4>
 
 In addition to the properties of a
 <a>MissingCharacteristicGenericAccessDevice</a>, its
@@ -170,6 +178,18 @@ In addition to the properties of a
 {{org.bluetooth.characteristic.gap.device_name}} characteristic. This
 characteristic returns <code>"GenericAccessDevice"</code> when read, and
 responds that writes have succeeded (without changing the value read).
+
+<h4 dfn-type="dfn">GenericAccessDevice</h4>
+
+In addition to the properties of a
+<a>MissingDescriptorGenericAccessDevice</a>, its
+{{org.bluetooth.characteristic.gap.device_name}} characteristic contains the following descriptors:
+
+: {{org.bluetooth.descriptor.gatt.characteristic_extended_properties}}
+:: Has the Writable Auxiliaries bit set.
+: {{org.bluetooth.descriptor.gatt.characteristic_user_description}}
+:: Returns <code>"Device Name"</code> when read, and responds that writes
+    have succeeded (without changing the value read).
 
 <h4 dfn-type="dfn">FailingGATTOperationsDevice</h4>
 

--- a/tests/index.bs
+++ b/tests/index.bs
@@ -1,0 +1,202 @@
+<pre class='metadata'>
+Title: Testing Web Bluetooth
+Status: CG-DRAFT
+ED: https://webbluetoothcg.github.io/web-bluetooth/tests
+Shortname: testing-web-bluetooth
+Level: 1
+Editor: See contributors on GitHub, , https://github.com/WebBluetoothCG/web-bluetooth/graphs/contributors
+Abstract: This document describes functions used in testing the Web Bluetooth API.
+
+Group: web-bluetooth-cg
+
+Markup Shorthands: css no
+Link Defaults: html (dfn) trusted event/the body element
+Link Defaults: web-bluetooth (dfn) valid uuid
+</pre>
+<pre class="biblio">
+{
+  "BLUETOOTH42": {
+    "href": "https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439",
+    "title": "BLUETOOTH SPECIFICATION Version 4.2",
+    "publisher": "Bluetooth SIG",
+    "date": "2 December 2014"
+  },
+  "BLUETOOTH-ASSIGNED": {
+    "href": "https://www.bluetooth.org/en-us/specification/assigned-numbers",
+    "title": "Assigned Numbers",
+    "status": "Living Standard",
+    "publisher": "Bluetooth SIG"
+  }
+}
+</pre>
+<pre class="anchors">
+spec: BLUETOOTH-ASSIGNED
+    type: enum; urlPrefix: https://developer.bluetooth.org/gatt/
+        urlPrefix: characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.
+            text: org.bluetooth.characteristic.gap.device_name; url: gap.device_name.xml#
+        urlPrefix: services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.
+            text: org.bluetooth.service.battery_service; url: battery_service.xml#
+            text: org.bluetooth.service.glucose; url: glucose.xml#
+            text: org.bluetooth.service.generic_access; url: generic_access.xml#
+            text: org.bluetooth.service.heart_rate; url: heart_rate.xml#
+spec: ui-events; urlPrefix: https://www.w3.org/TR/uievents/#
+    type: event
+        text: keypress; url: event-type-keypress
+    type: attribute
+        for: KeyboardEvent; text: key; url: widl-KeyboardEvent-key
+</pre>
+
+<style>
+.atrisk::before {
+  content: '\25C0    May depend on implementation details';
+}
+</style>
+
+<h2 id="introduction">Introduction</h2>
+
+<em>This section is non-normative.</em>
+
+Writing cross-browser tests for the
+<a href="https://webbluetoothcg.github.io/web-bluetooth/">Web Bluetooth API</a> is
+difficult because it interacts with devices that live outside the browser. This
+document describes APIs that aid in this testing, and can be implemented by each
+browser to either mock out the external interaction, or to configure an external
+test device to behave as the test needs.
+
+Tests using these functions are currently in <a
+href="https://code.google.com/p/chromium/codesearch/#chromium/src/third_party/WebKit/LayoutTests/bluetooth/">Chromium's
+repository</a>, will be moved to <a
+href="https://github.com/WebBluetoothCG/web-bluetooth/tests">this repository</a>
+soon, and will eventually live in the <a
+href="https://github.com/w3c/web-platform-tests">W3C's Web Platform Tests</a>.
+
+
+<h2 id="security-and-privacy">Security and privacy considerations</h2>
+
+These functions MUST NOT be exposed to web content. Only trusted testing
+code may access them.
+
+
+<h2 id="test-interfaces">Testing interfaces</h2>
+<pre class="idl">
+  partial interface Window {
+    readonly attribute TestRunner testRunner;
+    readonly attribute EventSender eventSender;
+  };
+</pre>
+
+
+<h2 id="test-runner">testRunner</h2>
+
+<pre class="idl">
+  interface TestRunner {
+    void setBluetoothMockDataSet(DOMString dataSetName);
+  };
+</pre>
+
+<h3 id="setBluetoothMockDataSet">setBluetoothMockDataSet</h3>
+
+When invoked, <dfn method
+for="TestRunner">setBluetoothMockDataSet(dataSetName)</dfn> MUST configure the
+UA's Bluetooth system to respond depending on the {{dataSetName}}:
+
+: <code>"NotPresentAdapter"</code>
+:: The UA has no Bluetooth implementation at all.
+: <code>"NotPoweredAdapter"</code>
+:: The UA's Bluetooth radio is disabled.
+: <code class="atrisk">"ScanFilterCheckingAdapter"</code>
+:: The UA may fail the test unless the test asks the adapter to start a
+    Bluetooth scan filtered to the {{org.bluetooth.service.glucose}},
+    {{org.bluetooth.service.heart_rate}}, and
+    {{org.bluetooth.service.battery_service}} Service UUIDs. The adapter
+    discovers a <a>BatteryDevice</a>.
+: <code>"EmptyAdapter"</code>
+:: No devices are nearby.
+: <code>"FailStartDiscoveryAdapter"</code>
+:: The UA fails to start a scan for devices.
+: <code>"GlucoseHeartRateAdapter"</code>
+:: The UA discovers a <a>HeartRateDevice</a> and then a <a>GlucoseDevice</a>.
+: <code>"MissingServiceGenericAccessAdapter"</code>
+:: The UA discovers a <a>MissingServiceGenericAccessDevice</a>.
+: <code>"MissingCharacteristicGenericAccessAdapter"</code>
+:: The UA discovers a <a>MissingCharacteristicGenericAccessDevice</a>.
+: <code>"GenericAccessAdapter"</code>
+:: The UA discovers a <a>GenericAccessDevice</a>.
+: <code>"FailingGATTOperationsAdapter"</code>
+:: The UA discovers a <a>FailingGATTOperationsDevice</a>.
+
+<h4 dfn-type="dfn">BaseDevice</h4>
+
+A device with a {{BluetoothDevice/vendorIDSource}} of "bluetooth", a
+{{BluetoothDevice/vendorID}} of <code>0xFFFF</code>, a
+{{BluetoothDevice/productID}} of <code>1</code>, and a
+{{BluetoothDevice/productVersion}} of <code>2</code>.
+
+<h4 dfn-type="dfn">BatteryDevice</h4>
+
+In addition to the properties of a <a>BaseDevice</a>, has a MAC address of
+<code>00:00:00:00:00:01</code>, the name <code>"Battery Device"</code>, and
+advertises {{org.bluetooth.service.battery_service}}.
+
+<h4 dfn-type="dfn">GlucoseDevice</h4>
+
+In addition to the properties of a <a>BaseDevice</a>, has a MAC address of
+<code>00:00:00:00:00:02</code>, the name <code>"Glucose Device"</code>, and
+advertises {{org.bluetooth.service.glucose}}.
+
+<h4 dfn-type="dfn">HeartRateDevice</h4>
+
+In addition to the properties of a <a>BaseDevice</a>, has a MAC address of
+<code>00:00:00:00:00:03</code>, the name <code>"Heart Rate Device"</code>, and
+advertises {{org.bluetooth.service.heart_rate}}.
+
+<h4 dfn-type="dfn">MissingServiceGenericAccessDevice</h4>
+
+In addition to the properties of a <a>BaseDevice</a>, has a MAC address of
+<code>00:00:00:00:00:00</code>, the name <code>"Generic Access
+Device"</code>, and accepts GATT connections. Its GATT Server is empty.
+
+<h4 dfn-type="dfn">MissingCharacteristicGenericAccessDevice</h4>
+
+In addition to the properties of a <a>MissingServiceGenericAccessDevice</a>, its
+GATT Server contains a primary {{org.bluetooth.service.generic_access}} service.
+This service contains no characteristics.
+
+<h4 dfn-type="dfn">GenericAccessDevice</h4>
+
+In addition to the properties of a
+<a>MissingCharacteristicGenericAccessDevice</a>, its
+{{org.bluetooth.service.generic_access}} service contains the
+{{org.bluetooth.characteristic.gap.device_name}} characteristic. This
+characteristic returns <code>"GenericAccessDevice"</code> when read, and
+responds that writes have succeeded (without changing the value read).
+
+<h4 dfn-type="dfn">FailingGATTOperationsDevice</h4>
+
+Let <dfn dfn><code>errorUUID(unsigned long id)</code></dfn> be the <a>valid
+UUID</a> consisting of <code>id.toString(16)</code> left-padded with
+<code>"0"</code>s to 8 characters, and then concatenated with
+<code>"-97e5-4cd7-b9f1-f5a427670c59"</code>. (These lower 96 bits were generated
+as a type 4 (random) UUID.)
+
+In addition to the properties of a <a>BaseDevice</a>, the
+<a>FailingGATTOperationsDevice</a> has a MAC address of
+<code>00:00:00:00:00:00</code>, the name <code>"Errors Device"</code>, and
+accepts GATT connections. Its GATT Server contains one service with UUID
+<code>errorUUID(0x100)</code>. This service contains 255 characteristics with
+UUIDs <code>errorUUID(0x101)</code> through <code>errorUUID(0x1ff)</code>. When
+read or written, the characteristic with UUID <code>errorUUID(which)</code>
+returns an Error Response ([[!BLUETOOTH42]] 3.F.3.4.1.1) with an error code of
+<code>which - 0x100</code>.
+
+<h2 id="event-sender">eventSender</h2>
+
+<pre class="idl">
+  interface EventSender {
+    void keyDown(DOMString code);
+  };
+</pre>
+
+<dfn method for="EventSender">keyDown(code)</dfn> dispatches a <a>trusted
+event</a> named {{keypress}} to <a>the body element</a>, with its
+{{KeyboardEvent/key}} attribute initialized to {{code}}.

--- a/tests/index.html
+++ b/tests/index.html
@@ -1051,8 +1051,9 @@ Parts of this work may be from another specification document.  If so, those par
         <li><a href="#heartratedevice"><span class="secno">4.1.4</span> <span class="content">HeartRateDevice</span></a>
         <li><a href="#missingservicegenericaccessdevice"><span class="secno">4.1.5</span> <span class="content">MissingServiceGenericAccessDevice</span></a>
         <li><a href="#missingcharacteristicgenericaccessdevice"><span class="secno">4.1.6</span> <span class="content">MissingCharacteristicGenericAccessDevice</span></a>
-        <li><a href="#genericaccessdevice"><span class="secno">4.1.7</span> <span class="content">GenericAccessDevice</span></a>
-        <li><a href="#failinggattoperationsdevice"><span class="secno">4.1.8</span> <span class="content">FailingGATTOperationsDevice</span></a>
+        <li><a href="#missingdescriptorgenericaccessdevice"><span class="secno">4.1.7</span> <span class="content">MissingDescriptorGenericAccessDevice</span></a>
+        <li><a href="#genericaccessdevice"><span class="secno">4.1.8</span> <span class="content">GenericAccessDevice</span></a>
+        <li><a href="#failinggattoperationsdevice"><span class="secno">4.1.9</span> <span class="content">FailingGATTOperationsDevice</span></a>
        </ul>
      </ul>
     <li><a href="#event-sender"><span class="secno">5</span> <span class="content">eventSender</span></a>
@@ -1122,6 +1123,11 @@ discovers a <a data-link-type="dfn" href="#batterydevice">BatteryDevice</a>.</p>
     <dd data-md="">
      <p>The UA fails to start a scan for devices.</p>
     <dt data-md="">
+     <p><code>"FailStopDiscoveryAdapter"</code></p>
+    <dd data-md="">
+     <p>Behaves like a GenericAccessAdapter, but the UA fails to stop the scan for
+devices.</p>
+    <dt data-md="">
      <p><code>"GlucoseHeartRateAdapter"</code></p>
     <dd data-md="">
      <p>The UA discovers a <a data-link-type="dfn" href="#heartratedevice">HeartRateDevice</a> and then a <a data-link-type="dfn" href="#glucosedevice">GlucoseDevice</a>.</p>
@@ -1133,6 +1139,10 @@ discovers a <a data-link-type="dfn" href="#batterydevice">BatteryDevice</a>.</p>
      <p><code>"MissingCharacteristicGenericAccessAdapter"</code></p>
     <dd data-md="">
      <p>The UA discovers a <a data-link-type="dfn" href="#missingcharacteristicgenericaccessdevice">MissingCharacteristicGenericAccessDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"MissingDescriptorGenericAccessAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA discovers a <a data-link-type="dfn" href="#missingdescriptorgenericaccessdevice">MissingDescriptorGenericAccessDevice</a>.</p>
     <dt data-md="">
      <p><code>"GenericAccessAdapter"</code></p>
     <dd data-md="">
@@ -1160,11 +1170,24 @@ Device"</code>, and accepts GATT connections. Its GATT Server is empty.</p>
    <p>In addition to the properties of a <a data-link-type="dfn" href="#missingservicegenericaccessdevice">MissingServiceGenericAccessDevice</a>, its
 GATT Server contains a primary <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a></code> service.
 This service contains no characteristics.</p>
-   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.7" data-lt="GenericAccessDevice" data-noexport="" id="genericaccessdevice"><span class="secno">4.1.7. </span><span class="content">GenericAccessDevice</span><a class="self-link" href="#genericaccessdevice"></a></h4>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.7" data-lt="MissingDescriptorGenericAccessDevice" data-noexport="" id="missingdescriptorgenericaccessdevice"><span class="secno">4.1.7. </span><span class="content">MissingDescriptorGenericAccessDevice</span><a class="self-link" href="#missingdescriptorgenericaccessdevice"></a></h4>
    <p>In addition to the properties of a <a data-link-type="dfn" href="#missingcharacteristicgenericaccessdevice">MissingCharacteristicGenericAccessDevice</a>, its <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a></code> service contains the <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">org.bluetooth.characteristic.gap.device_name</a></code> characteristic. This
 characteristic returns <code>"GenericAccessDevice"</code> when read, and
 responds that writes have succeeded (without changing the value read).</p>
-   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.8" data-lt="FailingGATTOperationsDevice" data-noexport="" id="failinggattoperationsdevice"><span class="secno">4.1.8. </span><span class="content">FailingGATTOperationsDevice</span><a class="self-link" href="#failinggattoperationsdevice"></a></h4>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.8" data-lt="GenericAccessDevice" data-noexport="" id="genericaccessdevice"><span class="secno">4.1.8. </span><span class="content">GenericAccessDevice</span><a class="self-link" href="#genericaccessdevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#missingdescriptorgenericaccessdevice">MissingDescriptorGenericAccessDevice</a>, its <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">org.bluetooth.characteristic.gap.device_name</a></code> characteristic contains the following descriptors:</p>
+   <dl>
+    <dt data-md="">
+     <p><code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_extended_properties.xml#">org.bluetooth.descriptor.gatt.characteristic_extended_properties</a></code></p>
+    <dd data-md="">
+     <p>Has the Writable Auxiliaries bit set.</p>
+    <dt data-md="">
+     <p><code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_user_description.xml#">org.bluetooth.descriptor.gatt.characteristic_user_description</a></code></p>
+    <dd data-md="">
+     <p>Returns <code>"Device Name"</code> when read, and responds that writes
+have succeeded (without changing the value read).</p>
+   </dl>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.9" data-lt="FailingGATTOperationsDevice" data-noexport="" id="failinggattoperationsdevice"><span class="secno">4.1.9. </span><span class="content">FailingGATTOperationsDevice</span><a class="self-link" href="#failinggattoperationsdevice"></a></h4>
    <p>Let <dfn data-dfn-type="dfn" data-noexport="" id="erroruuid-unsigned-long-id"><code>errorUUID(unsigned long id)</code><a class="self-link" href="#erroruuid-unsigned-long-id"></a></dfn> be the <a data-link-type="dfn" href="https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid">valid
 UUID</a> consisting of <code>id.toString(16)</code> left-padded with <code>"0"</code>s to 8 characters, and then concatenated with <code>"-97e5-4cd7-b9f1-f5a427670c59"</code>. (These lower 96 bits were generated
 as a type 4 (random) UUID.)</p>
@@ -1202,15 +1225,16 @@ event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.o
    <li><a href="#batterydevice">BatteryDevice</a><span>, in §4.1.1</span>
    <li><a href="#dom-eventsender-keydown-code-code">code</a><span>, in §5</span>
    <li><a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName</a><span>, in §4</span>
-   <li><a href="#erroruuid-unsigned-long-id">errorUUID(unsigned long id)</a><span>, in §4.1.8</span>
+   <li><a href="#erroruuid-unsigned-long-id">errorUUID(unsigned long id)</a><span>, in §4.1.9</span>
    <li><a href="#dom-window-eventsender">eventSender</a><span>, in §3</span>
    <li><a href="#eventsender">EventSender</a><span>, in §5</span>
-   <li><a href="#failinggattoperationsdevice">FailingGATTOperationsDevice</a><span>, in §4.1.7</span>
-   <li><a href="#genericaccessdevice">GenericAccessDevice</a><span>, in §4.1.6</span>
+   <li><a href="#failinggattoperationsdevice">FailingGATTOperationsDevice</a><span>, in §4.1.8</span>
+   <li><a href="#genericaccessdevice">GenericAccessDevice</a><span>, in §4.1.7</span>
    <li><a href="#glucosedevice">GlucoseDevice</a><span>, in §4.1.2</span>
    <li><a href="#heartratedevice">HeartRateDevice</a><span>, in §4.1.3</span>
    <li><a href="#dom-eventsender-keydown">keyDown(code)</a><span>, in §5</span>
    <li><a href="#missingcharacteristicgenericaccessdevice">MissingCharacteristicGenericAccessDevice</a><span>, in §4.1.5</span>
+   <li><a href="#missingdescriptorgenericaccessdevice">MissingDescriptorGenericAccessDevice</a><span>, in §4.1.6</span>
    <li><a href="#missingservicegenericaccessdevice">MissingServiceGenericAccessDevice</a><span>, in §4.1.4</span>
    <li><a href="#dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet(dataSetName)</a><span>, in §4.1</span>
    <li><a href="#testrunner">TestRunner</a><span>, in §4</span>
@@ -1222,6 +1246,8 @@ event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.o
     <a data-link-type="biblio" href="#biblio-bluetooth-assigned">[BLUETOOTH-ASSIGNED]</a> defines the following terms:
     <ul>
      <li><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">org.bluetooth.characteristic.gap.device_name</a>
+     <li><a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_extended_properties.xml#">org.bluetooth.descriptor.gatt.characteristic_extended_properties</a>
+     <li><a href="https://developer.bluetooth.org/gatt/descriptors/Pages/DescriptorViewer.aspx?u=org.bluetooth.descriptor.gatt.characteristic_user_description.xml#">org.bluetooth.descriptor.gatt.characteristic_user_description</a>
      <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#">org.bluetooth.service.battery_service</a>
      <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a>
      <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">org.bluetooth.service.glucose</a>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1,0 +1,1285 @@
+<!doctype html><html lang="en">
+ <head>
+  <meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+  <title>Testing Web Bluetooth</title>
+<style data-fill-with="stylesheet">/* This section copied from the W3C's ED styles. */
+
+	body {
+		color: black;
+		font-family: sans-serif;
+		margin: 0 auto;
+		max-width: 50em;
+		padding: 2em 1em 2em 70px;
+	}
+	:link { color: #00C; background: transparent }
+	:visited { color: #609; background: transparent }
+	a[href]:active { color: #C00; background: transparent }
+	a[href]:hover { background: #ffa }
+
+	a[href] img { border-style: none }
+
+	h1, h2, h3, h4, h5, h6 { text-align: left }
+	h1, h2, h3 { color: #005A9C; }
+	h1 { font: 170% sans-serif }
+	h2 { font: 140% sans-serif }
+	h3 { font: 120% sans-serif }
+	h4 { font: bold 100% sans-serif }
+	h5 { font: italic 100% sans-serif }
+	h6 { font: small-caps 100% sans-serif }
+
+	.hide { display: none }
+
+	div.head { margin-bottom: 1em }
+	div.head h1 { margin-top: 2em; clear: both }
+	div.head table { margin-left: 2em; margin-top: 2em }
+
+	p.copyright { font-size: small }
+	p.copyright small { font-size: small }
+
+	pre { margin-left: 2em }
+	dt { font-weight: bold }
+
+	ul.toc, ol.toc {
+		list-style: none;
+	}
+
+/* The rest copied from the CSSWG's default.css */
+
+	body {
+		counter-reset: exampleno figure issue;
+		max-width: 50em;
+		margin: 0 auto !important;
+		line-height: 1.5;
+	}
+
+/******************************************************************************/
+/*                                Sectioning                                  */
+/******************************************************************************/
+
+/** Headings ******************************************************************/
+
+	h1, h2, h3, h4, h5, h6, dt {
+		page-break-after: avoid;
+	}
+
+	h2, h3, h5, h6 {
+		margin-top: 3em;
+	}
+	h4 {
+		 margin-top: 4em;
+	}
+
+/** Subheadings ***************************************************************/
+
+	h1 + h2,
+	#subtitle + h2 {
+		/* #subtitle is a subtitle in an H2 under the H1 */
+		margin-top: 0;
+	}
+	h2 + h3,
+	h3 + h4,
+	h4 + h5,
+	h5 + h6 {
+		margin-top: 1.2em; /* = 1 x line-height */
+	}
+
+/** Section divider ***********************************************************/
+	/* &lt;hr> used to separate TMI into the second half of a section              */
+	hr:not([title]) {
+		font-size: 1.5em;
+		text-align: center;
+		margin: 1em auto;
+		height: auto;
+		border: transparent solid 0;
+		background: transparent;
+	}
+	hr:not([title])::before {
+		content: "\1F411\2003\2003\1F411\2003\2003\1F411";
+	}
+	/* note: &lt;hr> with title separates document header from contents */
+
+/******************************************************************************/
+/*                            Paragraphs and Lists                            */
+/******************************************************************************/
+
+	p {
+		margin: 1em 0;
+	}
+	dd     > p:first-child,
+	li     > p:first-child {
+		margin-top: 0;
+	}
+
+	ul, ol {
+		margin-left: 0;
+		padding-left: 2em;
+	}
+	li {
+		margin: 0.25em 2em 0.5em 0;
+		padding-left: 0;
+	}
+
+	dl dd {
+		margin: 0 0 1em 2em;
+	}
+	.head dd {
+		margin-bottom: 0;
+	}
+
+	/* Style for algorithms */
+	ol.algorithm ol {
+	 border-left: 1px solid #90b8de;
+	 margin-left: 1em;
+	}
+	ol.algorithm ol.algorithm {
+	 border-left: none;
+	 margin-left: 0;
+	}
+
+	/* Style for switch/case &lt;dl>s */
+	dl.switch > dd > ol.only {
+	 margin-left: 0;
+	}
+	dl.switch > dd > ol.algorithm {
+	 margin-left: -2em;
+	}
+	dl.switch {
+	 padding-left: 2em;
+	}
+	dl.switch > dt {
+	 text-indent: -1.5em;
+	 margin-top: 1em;
+	}
+	dl.switch > dt + dt {
+	 margin-top: 0;
+	}
+	dl.switch > dt::before {
+	 content: '\21AA';
+	 padding: 0 0.5em 0 0;
+	 display: inline-block;
+	 width: 1em;
+	 text-align: right;
+	 line-height: 0.5em;
+	}
+
+	/* Style for paragraphs I know are in MD-genned lists */
+	[data-md] > :first-child {
+		margin-top: 0;
+	}
+	[data-md] > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Inline Lists **************************************************************/
+	/* This is mostly to make the list inside the CR exit criteria more compact. */
+
+	ol.inline, ol.inline li {
+		display: inline;
+		padding: 0; margin: 0;
+	}
+	ol.inline {
+		counter-reset: list-item;
+	}
+	ol.inline li {
+		counter-increment: list-item;
+	}
+	ol.inline li::before {
+		content: "(" counter(list-item) ") ";
+		font-weight: bold;
+	}
+
+/** Terminology Markup ********************************************************/
+
+
+/******************************************************************************/
+/*                                 Inline Markup                              */
+/******************************************************************************/
+
+/** Terminology Markup ********************************************************/
+	dfn   { /* Defining instance */
+		font-weight: bolder;
+	}
+	a > i { /* Instance of term */
+		font-style: normal;
+	}
+	dt dfn code, code.idl {
+		font-size: inherit;
+	}
+	dfn var {
+		font-style: normal;
+	}
+
+/** Change Marking ************************************************************/
+
+	del { color: red;  text-decoration: line-through; }
+	ins { color: #080; text-decoration: underline;    }
+
+/** Miscellaneous improvements to inline formatting ***************************/
+
+	sup {
+		vertical-align: super;
+		font-size: 80%
+	}
+
+/******************************************************************************/
+/*                                    Code                                    */
+/******************************************************************************/
+
+/** General monospace/pre rules ***********************************************/
+
+	pre, code {
+		font-family: Menlo, Consolas, "DejaVu Sans Mono", monospace;
+		font-size: .9em;
+		page-break-inside: avoid;
+	}
+	pre {
+		margin-top: 1em;
+		margin-bottom: 1em;
+		overflow: auto;
+	}
+
+/** Syntax-Highlighted Code ***************************************************/
+
+	.example pre[class*="language-"],
+	.example [class*="language-"] pre,
+	.example pre[class*="lang-"],
+	.example [class*="lang-"] pre {
+		background: transparent; /* Prism applies a gray background that doesn't work well in the template. */
+	}
+
+/** Example Code **************************************************************/
+
+	div.html, div.xml,
+	pre.html, pre.xml {
+		padding: 0.5em;
+		margin: 1em 0;
+		position: relative;
+		clear: both;
+		color: #600;
+	}
+	pre.example,
+	pre.html,
+	pre.xml {
+		padding-top: 1.5em;
+	}
+
+	pre.illegal, .illegal pre
+	pre.deprecated, .deprecated pre {
+		color: red;
+	}
+
+/** IDL fragments *************************************************************/
+
+	pre.idl {
+		/* Match blue propdef boxes */
+		padding: .5em 1em;
+		background: #DEF;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+	}
+	pre.idl :link, pre.idl :visited {
+		color:inherit;
+		background:transparent;
+	}
+
+/** Inline CSS fragments ******************************************************/
+
+	.css.css, .property.property, .descriptor.descriptor {
+		color: #005a9c;
+		font-size: inherit;
+		font-family: inherit;
+	}
+	.css::before, .property::before, .descriptor::before {
+		content: "‘";
+	}
+	.css::after, .property::after, .descriptor::after {
+		content: "’";
+	}
+	.property, .descriptor {
+		/* Don't wrap property and descriptor names */
+		white-space: nowrap;
+	}
+	.type { /* CSS value &lt;type> */
+	font-style: italic;
+	}
+	pre .property::before, pre .property::after {
+		content: "";
+	}
+
+/** Inline markup fragments ***************************************************/
+
+	code.html, code.xml {
+		color: #660000;
+	}
+
+/** Autolinks produced using Bikeshed *****************************************/
+
+	[data-link-type="property"]::before,
+	[data-link-type="propdesc"]::before,
+	[data-link-type="descriptor"]::before,
+	[data-link-type="value"]::before,
+	[data-link-type="function"]::before,
+	[data-link-type="at-rule"]::before,
+	[data-link-type="selector"]::before,
+	[data-link-type="maybe"]::before {
+		content: "‘";
+	}
+	[data-link-type="property"]::after,
+	[data-link-type="propdesc"]::after,
+	[data-link-type="descriptor"]::after,
+	[data-link-type="value"]::after,
+	[data-link-type="function"]::after,
+	[data-link-type="at-rule"]::after,
+	[data-link-type="selector"]::after,
+	[data-link-type="maybe"]::after {
+		content: "’";
+	}
+
+	[data-link-type].production::before,
+	[data-link-type].production::after,
+	.prod [data-link-type]::before,
+	.prod [data-link-type]::after {
+		content: "";
+	}
+
+	[data-link-type=element]         { font-family: monospace; }
+	[data-link-type=element]::before { content: "&lt;" }
+	[data-link-type=element]::after  { content: ">" }
+
+	[data-link-type=biblio] {
+		white-space: pre;
+	}
+
+
+/******************************************************************************/
+/*                                    Links                                   */
+/******************************************************************************/
+
+/** General Hyperlinks ********************************************************/
+
+	/* We hyperlink a lot, so make it less intrusive */
+	a:link, a:visited {
+		color: inherit;
+		text-decoration: none;
+		border-bottom: 1px solid silver;
+	}
+	@supports (text-decoration-color: silver) {
+		a:link, a:visited {
+			border-bottom: none;
+			text-decoration: underline;
+			text-decoration-color: silver;
+		}
+		a:visited {
+			text-decoration-style: dotted;
+		}
+	}
+
+	a.logo:link, a.logo:visited { /* backout above styling for W3C logo */
+		padding: 0;
+		border: none;
+		text-decoration: none;
+	}
+
+/** Self-Links ****************************************************************/
+	/* Auto-generated links from an element to its own anchor, for usability */
+
+	.heading, .issue, .note, .example, li, dt {
+		position: relative;
+	}
+	a.self-link {
+		position: absolute;
+		top: 0;
+		left: -2.5em;
+		width: 2em;
+		height: 2em;
+		text-align: center;
+		border: none;
+		transition: opacity .2s;
+		opacity: .5;
+	}
+	a.self-link:hover {
+		opacity: 1;
+	}
+	.heading > a.self-link {
+		font-size: 83%;
+	}
+	li > a.self-link {
+		left: -3.5em;
+	}
+	dfn > a.self-link {
+		top: auto;
+		left: auto;
+		opacity: 0;
+		width: 1.5em;
+		height: 1.5em;
+		background: gray;
+		color: white;
+		font-style: normal;
+		transition: opacity .2s, background-color .2s, color .2s;
+	}
+	dfn:hover > a.self-link {
+		opacity: 1;
+	}
+	dfn > a.self-link:hover {
+		color: black;
+	}
+
+	a.self-link::before            { content: "¶"; }
+	.heading > a.self-link::before { content: "§"; }
+	dfn > a.self-link::before      { content: "#"; }
+
+/******************************************************************************/
+/*                                    Images                                  */
+/******************************************************************************/
+
+	img {
+		border-style: none;
+		color: white;
+	}
+
+	figure, div.figure, div.sidefigure {
+		page-break-inside: avoid;
+	}
+
+	div.figure, p.figure, div.sidefigure, figure {
+		text-align: center;
+		margin: 2.5em 0;
+	}
+	div.figure pre, div.sidefigure pre, figure pre {
+		text-align: left;
+		display: table;
+		margin: 1em auto;
+	}
+	.figure table, figure table {
+		margin: auto;
+	}
+	div.sidefigure, figure.sidefigure {
+		float: right;
+		width: 50%;
+		margin: 0 0 0.5em 0.5em
+	}
+	div.figure img, div.sidefigure img, figure img,
+	div.figure object, div.sidefigure object, figure object {
+		display: block;
+		margin: auto;
+		max-width: 100%
+	}
+	p.caption, figcaption, caption {
+		text-align: center;
+		font-style: italic;
+		font-size: 90%;
+	}
+	p.caption:not(.no-marker)::before, figcaption:not(.no-marker)::before {
+		content: "Figure " counter(figure) ". ";
+	}
+	p.caption::before, figcaption::before, figcaption > .marker {
+		font-weight: bold;
+	}
+	p.caption, figcaption {
+		counter-increment: figure;
+	}
+
+	/* DL list is indented 2em, but figure inside it is not */
+	dd > div.figure, dd > figure { margin-left: -2em }
+
+	pre.ascii-art {
+		display: table; /* shrinkwrap */
+		margin: 1em auto;
+	}
+
+	/* Displaying the output of text layout, particularly when
+		 line-breaking is being invoked, and thus having a
+		 visible width is good. */
+	pre.output {
+		margin: 1em;
+		border: solid thin silver;
+		padding: 0.25em;
+		display: table;
+	}
+
+/******************************************************************************/
+/*                             Colored Boxes                                  */
+/******************************************************************************/
+
+	.issue, .note, .example, .why, .advisement, blockquote {
+		padding: .5em;
+		border: .5em;
+		border-left-style: solid;
+		page-break-inside: avoid;
+	}
+	span.issue, span.note {
+		padding: .1em .5em .15em;
+		border-right-style: solid;
+	}
+
+	div.issue,
+	div.note,
+	div.example,
+	details.why,
+	blockquote {
+		margin: 1em auto;
+	}
+	.note  > p:first-child,
+	.issue > p:first-child,
+	blockquote > :first-child {
+		margin-top: 0;
+	}
+	blockquote > :last-child {
+		margin-bottom: 0;
+	}
+
+/** Blockquotes ***************************************************************/
+
+	blockquote {
+		border-color: silver;
+	}
+
+/** Open issue ****************************************************************/
+	/* not intended for CR+ publication */
+
+	.issue {
+		border-color: #E05252;
+		background: #FBE9E9;
+		counter-increment: issue;
+		overflow: auto;
+	}
+	.issue:not(.no-marker)::before {
+		content: "ISSUE " counter(issue);
+		padding-right: 1em;
+	}
+	.issue::before, .issue > .marker {
+		color: #AE1E1E;
+	}
+
+/** Example *******************************************************************/
+
+	.example {
+		border-color: #E0CB52;
+		background: #FCFAEE;
+		counter-increment: exampleno;
+		overflow: auto;
+		clear: both;
+	}
+	.example::before, .example > .marker {
+		color: #827017;
+		font-family: sans-serif;
+		min-width: 7.5em;
+		display: block;
+	}
+	.example:not(.no-marker)::before {
+		content: "EXAMPLE";
+		content: "EXAMPLE " counter(exampleno);
+	}
+	.invalid.example::before, .invalid.example > .marker,
+	.illegal.example::before, .illegal.example > .marker {
+		color: red;
+	}
+	.invalid.example:not(.no-marker)::before,
+	.illegal.example:not(.no-marker)::before {
+		content: "INVALID EXAMPLE";
+		content: "INVALID EXAMPLE" counter(exampleno);
+	}
+
+/** Non-normative Note ********************************************************/
+
+	.note, .why {
+		border-color: #52E052;
+		background: #E9FBE9;
+		overflow: auto;
+	}
+	.note::before, .note > .marker {
+		display: block;
+		color: hsl(120, 70%, 30%);
+	}
+
+/** Advisement Box ************************************************************/
+	/*  for attention-grabbing normative statements */
+
+	.advisement {
+		border-color: orange;
+		border-style: none solid;
+		background: #FFEECC;
+		text-align: center;
+	}
+	strong.advisement {
+		display: block;
+	}
+	/*.advisement::before { color: #FF8800; } */
+
+/** ??? ***********************************************************************/
+
+	details.why {
+		border-color: #52E052;
+		background: #E9FBE9;
+		display: block;
+	}
+
+	details.why > summary {
+		font-style: italic;
+		display: block;
+	}
+
+	details.why[open] > summary {
+		border-bottom: 1px silver solid;
+	}
+
+/** Spec Obsoletion Notice ****************************************************/
+	/* obnoxious obsoletion notice for older/abandoned specs. */
+
+	details.annoying-warning {
+		display: block;
+	}
+
+	details.annoying-warning[open] {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		text-align: center;
+		padding: .5em;
+		border: thick solid red;
+		border-radius: 1em;
+	}
+@media not print {
+	details.annoying-warning[open] {
+		position: fixed;
+		left: 1em;
+		right: 1em;
+		bottom: 1em;
+		z-index: 1000;
+	}
+}
+
+	details.annoying-warning:not([open]) > summary {
+		background: #fdd;
+		color: red;
+		font-weight: bold;
+		text-align: center;
+		padding: .5em;
+	}
+
+/******************************************************************************/
+/*                                    Tables                                  */
+/******************************************************************************/
+
+/** Property/Descriptor Definition Tables *************************************/
+
+	table.propdef, table.propdef-extra,
+	table.descdef, table.definition-table {
+		page-break-inside: avoid;
+		width: 100%;
+		margin: 1.2em 0;
+		border-left: 0.5em solid #8CCBF2;
+		padding: 0.5em 1em;
+		background: #DEF;
+		border-spacing: 0;
+	}
+
+	table.propdef td, table.propdef-extra td,
+	table.descdef td, table.definition-table td,
+	table.propdef th, table.propdef-extra th,
+	table.descdef th, table.definition-table th {
+		padding: 0.5em;
+		vertical-align: baseline;
+		border-bottom: 1px solid #bbd7e9;
+	}
+	table.propdef > tbody > tr:last-child th,
+	table.propdef-extra > tbody > tr:last-child th,
+	table.descdef > tbody > tr:last-child th,
+	table.definition-table > tbody > tr:last-child th,
+	table.propdef > tbody > tr:last-child td,
+	table.propdef-extra > tbody > tr:last-child td,
+	table.descdef > tbody > tr:last-child td,
+	table.definition-table > tbody > tr:last-child td {
+		border-bottom: 0;
+	}
+
+	table.propdef th,
+	table.propdef-extra th,
+	table.descdef th,
+	table.definition-table th {
+		font-style: italic;
+		font-weight: normal;
+		width: 8.3em;
+		padding-left: 1em;
+	}
+
+	/* For when values are extra-complex and need formatting for readability */
+	table td.pre {
+		white-space: pre-wrap;
+	}
+
+	/* A footnote at the bottom of a propdef */
+	table.propdef td.footnote,
+	table.propdef-extra td.footnote,
+	table.descdef td.footnote,
+	table.definition-table td.footnote {
+		padding-top: 0.6em;
+	}
+	table.propdef td.footnote::before,
+	table.propdef-extra td.footnote::before,
+	table.descdef td.footnote::before,
+	table.definition-table td.footnote::before {
+		content: " ";
+		display: block;
+		height: 0.6em;
+		width: 4em;
+		border-top: thin solid;
+	}
+
+/** Profile Tables ************************************************************/
+	/* table of required features in a CSS profile */
+
+	table.features th {
+		background: #00589f;
+		color: #fff;
+		text-align: left;
+		padding: 0.2em 0.2em 0.2em 0.5em;
+	}
+	table.features td {
+		vertical-align: top;
+		border-bottom: 1px solid #ccc;
+		padding: 0.3em 0.3em 0.3em 0.7em;
+	}
+
+/** Data tables (and properly marked-up proptables) ***************************/
+	/*
+		 &lt;table class="data"> highlights structural relationships in a table
+		 when correct markup is used (e.g. thead/tbody, th vs. td, scope attribute)
+
+		 Use class="complex data" for particularly complicated tables --
+		 (This will draw more lines: busier, but clearer.)
+
+		 Use class="long" on table cells with paragraph-like contents
+		 (This will adjust text alignment accordingly.)
+	*/
+
+	.data, .proptable {
+		margin: 1em auto;
+		border-collapse: collapse;
+		width: 100%;
+		border: hidden;
+	}
+	.data {
+		text-align: center;
+		width: auto;
+	}
+	.data caption {
+		width: 100%;
+	}
+
+	.data td, .data th,
+	.proptable td, .proptable th {
+		padding: 0.5em;
+		border-width: 1px;
+		border-color: silver;
+		border-top-style: solid;
+	}
+
+	.data thead td:empty {
+		padding: 0;
+		border: 0;
+	}
+
+	.data thead th[scope="row"],
+	.proptable thead th[scope="row"] {
+		text-align: right;
+		color: inherit;
+	}
+
+	.data thead,
+	.proptable thead,
+	.data tbody,
+	.proptable tbody {
+		color: inherit;
+		border-bottom: 2px solid;
+	}
+
+	.data colgroup {
+		border-left: 2px solid;
+	}
+
+	.data tbody th:first-child,
+	.proptable tbody th:first-child ,
+	.data tbody td[scope="row"]:first-child,
+	.proptable tbody td[scope="row"]:first-child {
+		text-align: right;
+		color: inherit;
+		border-right: 2px solid;
+		border-top: 1px solid silver;
+		padding-right: 1em;
+	}
+	.data.define td:last-child {
+		text-align: left;
+	}
+
+	.data tbody th[rowspan],
+	.proptable tbody th[rowspan],
+	.data tbody td[rowspan],
+	.proptable tbody td[rowspan]{
+		border-left:  1px solid silver;
+		border-right: 1px solid silver;
+	}
+
+	.complex.data th,
+	.complex.data td {
+		border: 1px solid silver;
+	}
+
+	.data td.long {
+	 vertical-align: baseline;
+	 text-align: left;
+	}
+
+	.data img {
+		vertical-align: middle;
+	}
+
+
+/******************************************************************************/
+/*                                  Indices                                   */
+/******************************************************************************/
+
+
+/** Table of Contents *********************************************************/
+
+	/* ToC not indented, but font style shows hierarchy */
+	ul.toc           { margin: 1em 0;     font-weight: bold; /*text-transform: uppercase;*/ }
+	ul.toc ul        { margin: 0;        font-weight: normal; text-transform: none; }
+	ul.toc ul ul     { margin: 0 0 0 2em; font-style: italic; }
+	ul.toc ul ul ul  { margin: 0; }
+	ul.toc > li      { margin: 1.5em 0; }
+	ul.toc ul.toc li { margin: 0.3em 0 0 0; }
+
+	ul.toc, ul.toc ul, ul.toc li { padding: 0; line-height: 1.3; }
+	ul.toc a { text-decoration: none; border-bottom-style: none; }
+	ul.toc a:hover, ul.toc a:focus  { border-bottom-style: solid; }
+	@supports (text-decoration-style: solid) {
+		ul.toc a:hover, ul.toc a:focus  {
+			border-bottom-style: none;
+			text-decoration-style: solid;
+		}
+	}
+	/*
+	ul.toc li li li, ul.toc li li li ul {margin-left: 0; display: inline}
+	ul.toc li li li ul, ul.toc li li li ul li {margin-left: 0; display: inline}
+	*/
+
+	/* Section numbers in a column of their own */
+	ul.toc {
+		margin-left: 5em
+	}
+	ul.toc span.secno {
+		float: left;
+		width: 4em;
+		margin-left: -5em;
+	}
+	ul.toc ul ul span.secno {
+		margin-left: -7em;
+	}
+	/*ul.toc span.secno {text-align: right}*/
+	ul.toc li {
+		clear: both;
+	}
+	/* If we had 'tab', floats would not be needed here:
+		 ul.toc span.secno {tab: 5em right; margin-right: 1em}
+		 ul.toc li {text-indent: 5em hanging}
+	 The second line in case items wrap
+	*/
+
+/** At-risk List **************************************************************/
+	/* Style for At Risk features (intended as editorial aid, not intended for publishing) */
+
+	.atrisk::before {
+	 float: right;
+	 margin-top: -0.25em;
+	 padding: 0.5em 1em 0.5em 0;
+	 text-indent: -0.9em;
+	 border: 1px solid;
+	 content: '\25C0    Not yet widely implemented';
+	 white-space: pre;
+	 font-size: small;
+	 background-color: white;
+	 color: gray;
+	 text-align: center;
+	}
+
+	.toc .atrisk::before { content:none }
+
+/** Index *********************************************************************/
+
+	/* Index Lists: Layout */
+	ul.indexlist       { margin-left: 0; columns: 15em; -webkit-columns: 15em; text-indent: 1em hanging; }
+	ul.indexlist li    { margin-left: 0; list-style: none; break-inside: avoid; word-break: break-word; }
+	ul.indexlist li li { margin-left: 1em }
+	ul.indexlist dl    { margin-top: 0; }
+	ul.indexlist dt    { margin: .2em 0 .2em 20px;}
+	ul.indexlist dd    { margin: .2em 0 .2em 40px;}
+	/* Index Lists: Typography */
+	ul.indexlist ul,
+	ul.indexlist dl { font-size: smaller; }
+	ul.indexlist li span {
+		white-space: nowrap;
+		position: absolute;
+		color: transparent; }
+	ul.indexlist li a:hover + span,
+	ul.indexlist li a:focus + span {
+		color: gray;
+	}
+	@media print {
+		ul.indexlist li span { color: gray; }
+	}
+
+/** Property Index Tables *****************************************************/
+	/* See also the data table styling section, which this effectively subclasses */
+
+	table.proptable {
+		font-size: small;
+		border-collapse: collapse;
+		border-spacing: 0;
+		text-align: left;
+		margin: 1em 0;
+	}
+
+	table.proptable td,
+	table.proptable th {
+		padding: 0.4em;
+		text-align: center;
+	}
+
+	table.proptable tr:hover td {
+		background: #DEF;
+	}
+	.propdef th {
+		font-style: italic;
+		font-weight: normal;
+		text-align: left;
+		width: 3em;
+	}
+	/* The link in the first column in the property table (formerly a TD) */
+	table.proptable td .property,
+	table.proptable th .property {
+		display: block;
+		text-align: left;
+		font-weight: bold;
+	}
+
+/******************************************************************************/
+/*                                    Print                                   */
+/******************************************************************************/
+
+	@media print {
+		html {
+			margin: 0 !important; }
+		body {
+			font-family: serif; }
+		th, td {
+			font-family: inherit; }
+		a {
+			color: inherit !important; }
+
+		a:link, a:visited {
+			text-decoration: none !important }
+		a:link::after, a:visited::after { /* create a cross-ref "see..." */ }
+		.example::before {
+			font-family: serif !important; }
+	}
+	@page {
+		margin: 1.5cm 1.1cm;
+	}
+
+</style>
+  <meta content="Bikeshed 1.0.0" name="generator">
+<style>
+  body {
+    padding-left: 160px;
+    background-image: url('https://www.w3.org/community/src/css/spec/back-cg-draft.png');
+    background-position: top left;
+    background-attachment: fixed;
+    background-repeat: no-repeat;
+  }
+</style>
+<style>
+.atrisk::before {
+  content: '\25C0    May depend on implementation details';
+}
+</style>
+ </head>
+ <body class="h-entry">
+  <div class="head">
+   <p data-fill-with="logo"></p>
+   <h1 class="p-name no-ref" id="title">Testing Web Bluetooth</h1>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-09-04">4 September 2015</time></span></h2>
+   <div data-fill-with="spec-metadata">
+    <dl>
+     <dt>This version:
+     <dd><a class="u-url" href="https://webbluetoothcg.github.io/web-bluetooth/tests">https://webbluetoothcg.github.io/web-bluetooth/tests</a>
+     <dt>Issue Tracking:
+     <dd><a href="https://github.com/WebBluetoothCG/web-bluetooth/issues/">GitHub</a>
+     <dt class="editor">Editor:
+     <dd class="editor p-author h-card vcard"><a class="p-name fn u-url url" href="https://github.com/WebBluetoothCG/web-bluetooth/graphs/contributors">See contributors on GitHub</a>
+    </dl>
+   </div>
+   <div data-fill-with="warning"></div>
+   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
+and related or neighboring rights to this work.
+In addition, as of 4 September 2015,
+the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
+which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
+Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
+   <hr title="Separator for header">
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
+  <div class="p-summary" data-fill-with="abstract">
+   <p>This document describes functions used in testing the Web Bluetooth API.</p>
+  </div>
+  <div data-fill-with="at-risk"></div>
+  <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>
+  <div data-fill-with="table-of-contents" role="navigation">
+   <ul class="toc" role="directory">
+    <li><a href="#introduction"><span class="secno">1</span> <span class="content">Introduction</span></a>
+    <li><a href="#security-and-privacy"><span class="secno">2</span> <span class="content">Security and privacy considerations</span></a>
+    <li><a href="#test-interfaces"><span class="secno">3</span> <span class="content">Testing interfaces</span></a>
+    <li>
+     <a href="#test-runner"><span class="secno">4</span> <span class="content">testRunner</span></a>
+     <ul class="toc">
+      <li>
+       <a href="#setBluetoothMockDataSet"><span class="secno">4.1</span> <span class="content">setBluetoothMockDataSet</span></a>
+       <ul class="toc">
+        <li><a href="#basedevice"><span class="secno">4.1.1</span> <span class="content">BaseDevice</span></a>
+        <li><a href="#batterydevice"><span class="secno">4.1.2</span> <span class="content">BatteryDevice</span></a>
+        <li><a href="#glucosedevice"><span class="secno">4.1.3</span> <span class="content">GlucoseDevice</span></a>
+        <li><a href="#heartratedevice"><span class="secno">4.1.4</span> <span class="content">HeartRateDevice</span></a>
+        <li><a href="#missingservicegenericaccessdevice"><span class="secno">4.1.5</span> <span class="content">MissingServiceGenericAccessDevice</span></a>
+        <li><a href="#missingcharacteristicgenericaccessdevice"><span class="secno">4.1.6</span> <span class="content">MissingCharacteristicGenericAccessDevice</span></a>
+        <li><a href="#genericaccessdevice"><span class="secno">4.1.7</span> <span class="content">GenericAccessDevice</span></a>
+        <li><a href="#failinggattoperationsdevice"><span class="secno">4.1.8</span> <span class="content">FailingGATTOperationsDevice</span></a>
+       </ul>
+     </ul>
+    <li><a href="#event-sender"><span class="secno">5</span> <span class="content">eventSender</span></a>
+    <li><a href="#conformance"><span class="secno"></span> <span class="content"> Conformance</span></a>
+    <li>
+     <a href="#index"><span class="secno"></span> <span class="content">Index</span></a>
+     <ul class="toc">
+      <li><a href="#index-defined-here"><span class="secno"></span> <span class="content">Terms defined by this specification</span></a>
+      <li><a href="#index-defined-elsewhere"><span class="secno"></span> <span class="content">Terms defined by reference</span></a>
+     </ul>
+    <li>
+     <a href="#references"><span class="secno"></span> <span class="content">References</span></a>
+     <ul class="toc">
+      <li><a href="#normative"><span class="secno"></span> <span class="content">Normative References</span></a>
+     </ul>
+    <li><a href="#idl-index"><span class="secno"></span> <span class="content">IDL Index</span></a>
+   </ul>
+  </div>
+  <main>
+   <h2 class="heading settled" data-level="1" id="introduction"><span class="secno">1. </span><span class="content">Introduction</span><a class="self-link" href="#introduction"></a></h2>
+   <p><em>This section is non-normative.</em></p>
+   <p>Writing cross-browser tests for the <a href="https://webbluetoothcg.github.io/web-bluetooth/">Web Bluetooth API</a> is
+difficult because it interacts with devices that live outside the browser. This
+document describes APIs that aid in this testing, and can be implemented by each
+browser to either mock out the external interaction, or to configure an external
+test device to behave as the test needs.</p>
+   <p>Tests using these functions are currently in <a href="https://code.google.com/p/chromium/codesearch/#chromium/src/third_party/WebKit/LayoutTests/bluetooth/">Chromium’s
+repository</a>, will be moved to <a href="https://github.com/WebBluetoothCG/web-bluetooth/tests">this repository</a> soon, and will eventually live in the <a href="https://github.com/w3c/web-platform-tests">W3C’s Web Platform Tests</a>.</p>
+   <h2 class="heading settled" data-level="2" id="security-and-privacy"><span class="secno">2. </span><span class="content">Security and privacy considerations</span><a class="self-link" href="#security-and-privacy"></a></h2>
+   <p>These functions MUST NOT be exposed to web content. Only trusted testing
+code may access them.</p>
+   <h2 class="heading settled" data-level="3" id="test-interfaces"><span class="secno">3. </span><span class="content">Testing interfaces</span><a class="self-link" href="#test-interfaces"></a></h2>
+<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a> {
+  readonly attribute <a data-link-type="idl-name" href="#testrunner">TestRunner</a> <dfn class="idl-code" data-dfn-for="Window" data-dfn-type="attribute" data-export="" data-readonly="" data-type="TestRunner " id="dom-window-testrunner">testRunner<a class="self-link" href="#dom-window-testrunner"></a></dfn>;
+  readonly attribute <a data-link-type="idl-name" href="#eventsender">EventSender</a> <dfn class="idl-code" data-dfn-for="Window" data-dfn-type="attribute" data-export="" data-readonly="" data-type="EventSender " id="dom-window-eventsender">eventSender<a class="self-link" href="#dom-window-eventsender"></a></dfn>;
+};
+</pre>
+   <h2 class="heading settled" data-level="4" id="test-runner"><span class="secno">4. </span><span class="content">testRunner</span><a class="self-link" href="#test-runner"></a></h2>
+<pre class="idl">interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="testrunner">TestRunner<a class="self-link" href="#testrunner"></a></dfn> {
+  void <a class="idl-code" data-link-type="method" href="#dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet</a>(DOMString <dfn class="idl-code" data-dfn-for="TestRunner/setBluetoothMockDataSet(dataSetName)" data-dfn-type="argument" data-export="" id="dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName<a class="self-link" href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname"></a></dfn>);
+};
+</pre>
+   <h3 class="heading settled" data-level="4.1" id="setBluetoothMockDataSet"><span class="secno">4.1. </span><span class="content">setBluetoothMockDataSet</span><a class="self-link" href="#setBluetoothMockDataSet"></a></h3>
+   <p>When invoked, <dfn class="idl-code" data-dfn-for="TestRunner" data-dfn-type="method" data-export="" id="dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet(dataSetName)<a class="self-link" href="#dom-testrunner-setbluetoothmockdataset"></a></dfn> MUST configure the
+UA’s Bluetooth system to respond depending on the <code class="idl"><a data-link-type="idl" href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName</a></code>:</p>
+   <dl>
+    <dt data-md="">
+     <p><code>"NotPresentAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA has no Bluetooth implementation at all.</p>
+    <dt data-md="">
+     <p><code>"NotPoweredAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA’s Bluetooth radio is disabled.</p>
+    <dt data-md="">
+     <p><code class="atrisk">"ScanFilterCheckingAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA may fail the test unless the test asks the adapter to start a
+Bluetooth scan filtered to the <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">org.bluetooth.service.glucose</a></code>, <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">org.bluetooth.service.heart_rate</a></code>, and <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#">org.bluetooth.service.battery_service</a></code> Service UUIDs. The adapter
+discovers a <a data-link-type="dfn" href="#batterydevice">BatteryDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"EmptyAdapter"</code></p>
+    <dd data-md="">
+     <p>No devices are nearby.</p>
+    <dt data-md="">
+     <p><code>"FailStartDiscoveryAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA fails to start a scan for devices.</p>
+    <dt data-md="">
+     <p><code>"GlucoseHeartRateAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA discovers a <a data-link-type="dfn" href="#heartratedevice">HeartRateDevice</a> and then a <a data-link-type="dfn" href="#glucosedevice">GlucoseDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"MissingServiceGenericAccessAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA discovers a <a data-link-type="dfn" href="#missingservicegenericaccessdevice">MissingServiceGenericAccessDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"MissingCharacteristicGenericAccessAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA discovers a <a data-link-type="dfn" href="#missingcharacteristicgenericaccessdevice">MissingCharacteristicGenericAccessDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"GenericAccessAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA discovers a <a data-link-type="dfn" href="#genericaccessdevice">GenericAccessDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"FailingGATTOperationsAdapter"</code></p>
+    <dd data-md="">
+     <p>The UA discovers a <a data-link-type="dfn" href="#failinggattoperationsdevice">FailingGATTOperationsDevice</a>.</p>
+   </dl>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.1" data-lt="BaseDevice" data-noexport="" id="basedevice"><span class="secno">4.1.1. </span><span class="content">BaseDevice</span><a class="self-link" href="#basedevice"></a></h4>
+   <p>A device with a <code class="idl"><a data-link-type="idl" href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-vendoridsource">vendorIDSource</a></code> of "bluetooth", a <code class="idl"><a data-link-type="idl" href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-vendorid">vendorID</a></code> of <code>0xFFFF</code>, a <code class="idl"><a data-link-type="idl" href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-productid">productID</a></code> of <code>1</code>, and a <code class="idl"><a data-link-type="idl" href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-productversion">productVersion</a></code> of <code>2</code>.</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.2" data-lt="BatteryDevice" data-noexport="" id="batterydevice"><span class="secno">4.1.2. </span><span class="content">BatteryDevice</span><a class="self-link" href="#batterydevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#basedevice">BaseDevice</a>, has a MAC address of <code>00:00:00:00:00:01</code>, the name <code>"Battery Device"</code>, and
+advertises <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#">org.bluetooth.service.battery_service</a></code>.</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.3" data-lt="GlucoseDevice" data-noexport="" id="glucosedevice"><span class="secno">4.1.3. </span><span class="content">GlucoseDevice</span><a class="self-link" href="#glucosedevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#basedevice">BaseDevice</a>, has a MAC address of <code>00:00:00:00:00:02</code>, the name <code>"Glucose Device"</code>, and
+advertises <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">org.bluetooth.service.glucose</a></code>.</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.4" data-lt="HeartRateDevice" data-noexport="" id="heartratedevice"><span class="secno">4.1.4. </span><span class="content">HeartRateDevice</span><a class="self-link" href="#heartratedevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#basedevice">BaseDevice</a>, has a MAC address of <code>00:00:00:00:00:03</code>, the name <code>"Heart Rate Device"</code>, and
+advertises <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">org.bluetooth.service.heart_rate</a></code>.</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.5" data-lt="MissingServiceGenericAccessDevice" data-noexport="" id="missingservicegenericaccessdevice"><span class="secno">4.1.5. </span><span class="content">MissingServiceGenericAccessDevice</span><a class="self-link" href="#missingservicegenericaccessdevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#basedevice">BaseDevice</a>, has a MAC address of <code>00:00:00:00:00:00</code>, the name <code>"Generic Access
+Device"</code>, and accepts GATT connections. Its GATT Server is empty.</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.6" data-lt="MissingCharacteristicGenericAccessDevice" data-noexport="" id="missingcharacteristicgenericaccessdevice"><span class="secno">4.1.6. </span><span class="content">MissingCharacteristicGenericAccessDevice</span><a class="self-link" href="#missingcharacteristicgenericaccessdevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#missingservicegenericaccessdevice">MissingServiceGenericAccessDevice</a>, its
+GATT Server contains a primary <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a></code> service.
+This service contains no characteristics.</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.7" data-lt="GenericAccessDevice" data-noexport="" id="genericaccessdevice"><span class="secno">4.1.7. </span><span class="content">GenericAccessDevice</span><a class="self-link" href="#genericaccessdevice"></a></h4>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#missingcharacteristicgenericaccessdevice">MissingCharacteristicGenericAccessDevice</a>, its <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a></code> service contains the <code class="idl"><a data-link-type="idl" href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">org.bluetooth.characteristic.gap.device_name</a></code> characteristic. This
+characteristic returns <code>"GenericAccessDevice"</code> when read, and
+responds that writes have succeeded (without changing the value read).</p>
+   <h4 class="heading settled" data-dfn-type="dfn" data-level="4.1.8" data-lt="FailingGATTOperationsDevice" data-noexport="" id="failinggattoperationsdevice"><span class="secno">4.1.8. </span><span class="content">FailingGATTOperationsDevice</span><a class="self-link" href="#failinggattoperationsdevice"></a></h4>
+   <p>Let <dfn data-dfn-type="dfn" data-noexport="" id="erroruuid-unsigned-long-id"><code>errorUUID(unsigned long id)</code><a class="self-link" href="#erroruuid-unsigned-long-id"></a></dfn> be the <a data-link-type="dfn" href="https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid">valid
+UUID</a> consisting of <code>id.toString(16)</code> left-padded with <code>"0"</code>s to 8 characters, and then concatenated with <code>"-97e5-4cd7-b9f1-f5a427670c59"</code>. (These lower 96 bits were generated
+as a type 4 (random) UUID.)</p>
+   <p>In addition to the properties of a <a data-link-type="dfn" href="#basedevice">BaseDevice</a>, the <a data-link-type="dfn" href="#failinggattoperationsdevice">FailingGATTOperationsDevice</a> has a MAC address of <code>00:00:00:00:00:00</code>, the name <code>"Errors Device"</code>, and
+accepts GATT connections. Its GATT Server contains one service with UUID <code>errorUUID(0x100)</code>. This service contains 255 characteristics with
+UUIDs <code>errorUUID(0x101)</code> through <code>errorUUID(0x1ff)</code>. When
+read or written, the characteristic with UUID <code>errorUUID(which)</code> returns an Error Response (<a data-link-type="biblio" href="#biblio-bluetooth42">[BLUETOOTH42]</a> 3.F.3.4.1.1) with an error code of <code>which - 0x100</code>.</p>
+   <h2 class="heading settled" data-level="5" id="event-sender"><span class="secno">5. </span><span class="content">eventSender</span><a class="self-link" href="#event-sender"></a></h2>
+<pre class="idl">interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="eventsender">EventSender<a class="self-link" href="#eventsender"></a></dfn> {
+  void <a class="idl-code" data-link-type="method" href="#dom-eventsender-keydown">keyDown</a>(DOMString <dfn class="idl-code" data-dfn-for="EventSender/keyDown(code)" data-dfn-type="argument" data-export="" id="dom-eventsender-keydown-code-code">code<a class="self-link" href="#dom-eventsender-keydown-code-code"></a></dfn>);
+};
+</pre>
+   <p><dfn class="idl-code" data-dfn-for="EventSender" data-dfn-type="method" data-export="" id="dom-eventsender-keydown">keyDown(code)<a class="self-link" href="#dom-eventsender-keydown"></a></dfn> dispatches a <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-events-trusted">trusted
+event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#event-type-keypress">keypress</a></code> to <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">the body element</a>, with its <code class="idl"><a data-link-type="idl" href="https://www.w3.org/TR/uievents/#widl-KeyboardEvent-key">key</a></code> attribute initialized to <code class="idl"><a data-link-type="idl" href="#dom-eventsender-keydown-code-code">code</a></code>.</p>
+  </main>
+  <h2 class="no-ref no-num heading settled" id="conformance"><span class="content"> Conformance</span><a class="self-link" href="#conformance"></a></h2>
+  <p> Conformance requirements are expressed with a combination of descriptive assertions and RFC 2119 terminology.
+        The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL”
+        in the normative parts of this document
+        are to be interpreted as described in RFC 2119.
+        However, for readability,
+        these words do not appear in all uppercase letters in this specification. </p>
+  <p> All of the text of this specification is normative
+        except sections explicitly marked as non-normative, examples, and notes. <a data-link-type="biblio" href="#biblio-rfc2119">[RFC2119]</a> </p>
+  <p> Examples in this specification are introduced with the words “for example”
+        or are set apart from the normative text with <code>class="example"</code>, like this: </p>
+  <div class="example" id="example-ae2b6bc0"><a class="self-link" href="#example-ae2b6bc0"></a> This is an example of an informative example. </div>
+  <p> Informative notes begin with the word “Note”
+        and are set apart from the normative text with <code>class="note"</code>, like this: </p>
+  <p class="note" role="note"> Note, this is an informative note. </p>
+  <h2 class="no-num heading settled" id="index"><span class="content">Index</span><a class="self-link" href="#index"></a></h2>
+  <h3 class="no-num heading settled" id="index-defined-here"><span class="content">Terms defined by this specification</span><a class="self-link" href="#index-defined-here"></a></h3>
+  <ul class="indexlist">
+   <li><a href="#basedevice">BaseDevice</a><span>, in §4.1</span>
+   <li><a href="#batterydevice">BatteryDevice</a><span>, in §4.1.1</span>
+   <li><a href="#dom-eventsender-keydown-code-code">code</a><span>, in §5</span>
+   <li><a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName</a><span>, in §4</span>
+   <li><a href="#erroruuid-unsigned-long-id">errorUUID(unsigned long id)</a><span>, in §4.1.8</span>
+   <li><a href="#dom-window-eventsender">eventSender</a><span>, in §3</span>
+   <li><a href="#eventsender">EventSender</a><span>, in §5</span>
+   <li><a href="#failinggattoperationsdevice">FailingGATTOperationsDevice</a><span>, in §4.1.7</span>
+   <li><a href="#genericaccessdevice">GenericAccessDevice</a><span>, in §4.1.6</span>
+   <li><a href="#glucosedevice">GlucoseDevice</a><span>, in §4.1.2</span>
+   <li><a href="#heartratedevice">HeartRateDevice</a><span>, in §4.1.3</span>
+   <li><a href="#dom-eventsender-keydown">keyDown(code)</a><span>, in §5</span>
+   <li><a href="#missingcharacteristicgenericaccessdevice">MissingCharacteristicGenericAccessDevice</a><span>, in §4.1.5</span>
+   <li><a href="#missingservicegenericaccessdevice">MissingServiceGenericAccessDevice</a><span>, in §4.1.4</span>
+   <li><a href="#dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet(dataSetName)</a><span>, in §4.1</span>
+   <li><a href="#testrunner">TestRunner</a><span>, in §4</span>
+   <li><a href="#dom-window-testrunner">testRunner</a><span>, in §3</span>
+  </ul>
+  <h3 class="no-num heading settled" id="index-defined-elsewhere"><span class="content">Terms defined by reference</span><a class="self-link" href="#index-defined-elsewhere"></a></h3>
+  <ul class="indexlist">
+   <li>
+    <a data-link-type="biblio" href="#biblio-bluetooth-assigned">[BLUETOOTH-ASSIGNED]</a> defines the following terms:
+    <ul>
+     <li><a href="https://developer.bluetooth.org/gatt/characteristics/Pages/CharacteristicViewer.aspx?u=org.bluetooth.characteristic.gap.device_name.xml#">org.bluetooth.characteristic.gap.device_name</a>
+     <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.battery_service.xml#">org.bluetooth.service.battery_service</a>
+     <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a>
+     <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">org.bluetooth.service.glucose</a>
+     <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">org.bluetooth.service.heart_rate</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
+    <ul>
+     <li><a href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/dom.html#the-body-element-2">the body element</a>
+     <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#concept-events-trusted">trusted event</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-ui-events">[UI-EVENTS]</a> defines the following terms:
+    <ul>
+     <li><a href="https://www.w3.org/TR/uievents/#widl-KeyboardEvent-key">key</a>
+     <li><a href="https://www.w3.org/TR/uievents/#event-type-keypress">keypress</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-web-bluetooth-1">[web-bluetooth]</a> defines the following terms:
+    <ul>
+     <li><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-productid">productID</a>
+     <li><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-productversion">productVersion</a>
+     <li><a href="https://webbluetoothcg.github.io/web-bluetooth/#valid-uuid">valid uuid</a>
+     <li><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-vendorid">vendorID</a>
+     <li><a href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-vendoridsource">vendorIDSource</a>
+    </ul>
+  </ul>
+  <h2 class="no-num heading settled" id="references"><span class="content">References</span><a class="self-link" href="#references"></a></h2>
+  <h3 class="no-num heading settled" id="normative"><span class="content">Normative References</span><a class="self-link" href="#normative"></a></h3>
+  <dl>
+   <dt id="biblio-bluetooth-assigned"><a class="self-link" href="#biblio-bluetooth-assigned"></a>[BLUETOOTH-ASSIGNED]
+   <dd><a href="https://www.bluetooth.org/en-us/specification/assigned-numbers">Assigned Numbers</a>. Living Standard. URL: <a href="https://www.bluetooth.org/en-us/specification/assigned-numbers">https://www.bluetooth.org/en-us/specification/assigned-numbers</a>
+   <dt id="biblio-bluetooth42"><a class="self-link" href="#biblio-bluetooth42"></a>[BLUETOOTH42]
+   <dd><a href="https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439">BLUETOOTH SPECIFICATION Version 4.2</a>. 2 December 2014. URL: <a href="https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439">https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439</a>
+   <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
+   <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
+   <dt id="biblio-ui-events"><a class="self-link" href="#biblio-ui-events"></a>[UI-EVENTS]
+   <dd>Gary Kacmarcik; Travis Leithead. <a href="http://www.w3.org/TR/uievents/">UI Events (formerly DOM Level 3 Events)</a>. 28 April 2015. WD. URL: <a href="http://www.w3.org/TR/uievents/">http://www.w3.org/TR/uievents/</a>
+   <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
+   <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
+   <dt id="biblio-web-bluetooth"><a class="self-link" href="#biblio-web-bluetooth"></a>[WEB-BLUETOOTH]
+   <dd>Jeffrey Yasskin. <a href="https://webbluetoothcg.github.io/web-bluetooth/">Web Bluetooth</a>. Draft Community Group Report. URL: <a href="https://webbluetoothcg.github.io/web-bluetooth/">https://webbluetoothcg.github.io/web-bluetooth/</a>
+  </dl>
+  <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
+<pre class="idl">partial interface <a class="idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/browsers.html#window">Window</a> {
+  readonly attribute <a data-link-type="idl-name" href="#testrunner">TestRunner</a> <a data-readonly="" data-type="TestRunner " href="#dom-window-testrunner">testRunner</a>;
+  readonly attribute <a data-link-type="idl-name" href="#eventsender">EventSender</a> <a data-readonly="" data-type="EventSender " href="#dom-window-eventsender">eventSender</a>;
+};
+
+interface <a href="#testrunner">TestRunner</a> {
+  void <a class="idl-code" data-link-type="method" href="#dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet</a>(DOMString <a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName</a>);
+};
+
+interface <a href="#eventsender">EventSender</a> {
+  void <a class="idl-code" data-link-type="method" href="#dom-eventsender-keydown">keyDown</a>(DOMString <a href="#dom-eventsender-keydown-code-code">code</a>);
+};
+
+</pre>
+ </body>
+</html>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1006,9 +1006,9 @@
  </head>
  <body class="h-entry">
   <div class="head">
-   <p data-fill-with="logo"></p>
+   <div data-fill-with="logo"></div>
    <h1 class="p-name no-ref" id="title">Testing Web Bluetooth</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-09-04">4 September 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-09-08">8 September 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1020,17 +1020,25 @@
     </dl>
    </div>
    <div data-fill-with="warning"></div>
-   <p class="copyright" data-fill-with="copyright"><a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" src="https://licensebuttons.net/p/zero/1.0/80x15.png"></a> To the extent possible under law, the editors have waived all copyright
-and related or neighboring rights to this work.
-In addition, as of 4 September 2015,
-the editors have made this specification available under the <a href="http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0" rel="license">Open Web Foundation Agreement Version 1.0</a>,
-which is available at http://www.openwebfoundation.org/legal/the-owf-1-0-agreements/owfa-1-0.
-Parts of this work may be from another specification document.  If so, those parts are instead covered by the license of that specification document. </p>
+   <p class="copyright" data-fill-with="copyright"><a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a> © 2015 the Contributors to the Web Bluetooth Specification, published by the <a href="https://www.w3.org/community/web-bluetooth/">Web Bluetooth Community Group</a> under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a>.
+A human-readable <a href="http://www.w3.org/community/about/agreements/cla-deed/">summary</a> is available. </p>
    <hr title="Separator for header">
   </div>
   <h2 class="no-num no-toc no-ref heading settled" id="abstract"><span class="content">Abstract</span></h2>
   <div class="p-summary" data-fill-with="abstract">
    <p>This document describes functions used in testing the Web Bluetooth API.</p>
+  </div>
+  <h2 class="no-num no-toc no-ref heading settled" id="status"><span class="content">Status of this document</span></h2>
+  <div data-fill-with="status">
+   <p> This specification was published by the <a href="https://www.w3.org/community/web-bluetooth/">Web Bluetooth Community Group</a>.
+  It is not a W3C Standard nor is it on the W3C Standards Track.
+
+  Please note that under the <a href="https://www.w3.org/community/about/agreements/cla/">W3C Community Contributor License Agreement (CLA)</a> there is a limited opt-out and other conditions apply.
+
+  Learn more about <a href="http://www.w3.org/community/">W3C Community and Business Groups</a>. </p>
+   <p> Changes to this document may be tracked at <a href="https://github.com/WebBluetoothCG/web-bluetooth/commits/gh-pages">https://github.com/WebBluetoothCG/web-bluetooth/commits/gh-pages</a>. </p>
+   <p>If you wish to make comments regarding this document, please send them to <a href="mailto:public-web-bluetooth@w3.org">public-web-bluetooth@w3.org</a> (<a href="mailto:public-web-bluetooth-request@w3.org?subject=subscribe">subscribe</a>, <a href="http://lists.w3.org/Archives/Public/public-web-bluetooth/">archives</a>).</p>
+   <p> <strong class="advisement">This specification does not yet reflect the consensus of the Web Bluetooth CG. It is presented by the Chromium developers in the hope that other implementers will find it useful. It may be withdrawn if they don’t.</strong> </p>
   </div>
   <div data-fill-with="at-risk"></div>
   <h2 class="no-num no-toc no-ref heading settled" id="contents"><span class="content">Table of Contents</span></h2>


### PR DESCRIPTION
This matches the current Chromium test APIs (eventSender.keyDown and
testRunner.setBluetoothMockDataSet()) except:
* FailingConnectionsAdapter is omitted because the BT standard doesn't include
  any portable error codes.
* FailingGATTOperationsAdapter returns an ATT Error Response corresponding to
  its UUID, instead of the Chromium-specific error code used in the current
  Chromium tests.

@scheib @g-ortuno, can you double-check that I've matched the Chromium test APIs? This PR doesn't include the new interfaces I'm adding in https://codereview.chromium.org/1325953002/.

@yrliou @shuangMoz, we'd like your implementation to be able to share as many of our tests as possible. Please let us know what of this we need to change for it to work for you.

Rendered spec at https://rawgit.com/jyasskin/web-bluetooth-1/test-apis/tests/index.html.