### PR TITLE
Add interfaces for testing that the chooser can restart discovery.

### DIFF
--- a/tests/index.bs
+++ b/tests/index.bs
@@ -126,7 +126,10 @@ respond depending on the {{dataSetName}}:
 :: Behaves like a GenericAccessAdapter, but the UA fails to stop the scan for
     devices.
 : <code>"GlucoseHeartRateAdapter"</code>
-:: The UA discovers a <a>HeartRateDevice</a> and then a <a>GlucoseDevice</a>.
+:: The UA discovers a <a>HeartRateDevice</a> and a <a>GlucoseDevice</a>.
+: <code>"SecondDiscoveryFindsHeartRateAdapter"</code>
+:: In the first discovery session, the UA finds no devices. In the second, it
+    discovers a <a>HeartRateDevice</a>.
 : <code>"MissingServiceGenericAccessAdapter"</code>
 :: The UA discovers a <a>MissingServiceGenericAccessDevice</a>.
 : <code>"MissingCharacteristicGenericAccessAdapter"</code>
@@ -274,6 +277,8 @@ action corresponding to the {{event}}:
 :: The user cancelled the prompt.
 : <code>"selected"</code>
 :: The user selected the device with an {{BluetoothDevice/id}} of {{argument}}.
+: <code>"rescan"</code>
+:: The user requested another bluetooth scan.
 
 
 <h2 id="event-sender">eventSender</h2>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1147,7 +1147,12 @@ devices.</p>
     <dt data-md="">
      <p><code>"GlucoseHeartRateAdapter"</code></p>
     <dd data-md="">
-     <p>The UA discovers a <a data-link-type="dfn" href="#heartratedevice">HeartRateDevice</a> and then a <a data-link-type="dfn" href="#glucosedevice">GlucoseDevice</a>.</p>
+     <p>The UA discovers a <a data-link-type="dfn" href="#heartratedevice">HeartRateDevice</a> and a <a data-link-type="dfn" href="#glucosedevice">GlucoseDevice</a>.</p>
+    <dt data-md="">
+     <p><code>"SecondDiscoveryFindsHeartRateAdapter"</code></p>
+    <dd data-md="">
+     <p>In the first discovery session, the UA finds no devices. In the second, it
+discovers a <a data-link-type="dfn" href="#heartratedevice">HeartRateDevice</a>.</p>
     <dt data-md="">
      <p><code>"MissingServiceGenericAccessAdapter"</code></p>
     <dd data-md="">
@@ -1277,6 +1282,10 @@ action corresponding to the <code class="idl"><a data-link-type="idl" href="#dom
      <p><code>"selected"</code></p>
     <dd data-md="">
      <p>The user selected the device with an <code class="idl"><a data-link-type="idl" href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothdevice-id">id</a></code> of <code class="idl"><a data-link-type="idl" href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">argument</a></code>.</p>
+    <dt data-md="">
+     <p><code>"rescan"</code></p>
+    <dd data-md="">
+     <p>The user requested another bluetooth scan.</p>
    </dl>
    <h2 class="heading settled" data-level="5" id="event-sender"><span class="secno">5. </span><span class="content">eventSender</span><a class="self-link" href="#event-sender"></a></h2>
 <pre class="idl">interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="eventsender">EventSender<a class="self-link" href="#eventsender"></a></dfn> {


### PR DESCRIPTION
Preview at https://rawgit.com/jyasskin/web-bluetooth-1/chooser-rescan-test/tests/index.html.

These are added to Chromium in https://codereview.chromium.org/1353053002.