### PR TITLE
Make getBluetoothManualChooserEvents asynchronous.

### DIFF
--- a/tests/index.bs
+++ b/tests/index.bs
@@ -8,7 +8,7 @@ Level: 1
 Editor: See contributors on GitHub, , https://github.com/WebBluetoothCG/web-bluetooth/graphs/contributors
 Abstract: This document describes functions used in testing the Web Bluetooth API.
 Status Text: <strong class="advisement">This specification does not yet reflect the consensus of the Web Bluetooth CG. It is presented by the Chromium developers in the hope that other implementers will find it useful. It may be withdrawn if they don't.</strong>
-Markup Shorthands: css no
+Markup Shorthands: css no, markdown yes
 Link Defaults: html (dfn) trusted event/the body element
 Link Defaults: web-bluetooth (dfn) valid uuid
 </pre>
@@ -91,10 +91,12 @@ code may access them.
 <h2 id="test-runner">testRunner</h2>
 
 <pre class="idl">
+  callback BluetoothManualChooserEventsCallback = void(sequence&lt;DOMString> events);
+
   interface TestRunner {
     void setBluetoothMockDataSet(DOMString dataSetName);
     void setBluetoothManualChooser();
-    sequence&lt;DOMString> getBluetoothManualChooserEvents();
+    void getBluetoothManualChooserEvents(BluetoothManualChooserEventsCallback callback);
     void sendBluetoothManualChooserEvent(DOMString event, DOMString argument);
   };
 </pre>
@@ -229,7 +231,7 @@ interaction with the prompt (see
 
 <h3 dfn-type="method" for="TestRunner">getBluetoothManualChooserEvents()</h3>
 
-When invoked, {{TestRunner/getBluetoothManualChooserEvents()}} MUST return the
+When invoked, {{TestRunner/getBluetoothManualChooserEvents(callback)}} MUST call `callback` with the
 list of events that have been recorded by the <a>manual chooser</a> since
 {{TestRunner/getBluetoothManualChooserEvents()}} was last called. Each event is
 encoded as string, as follows:
@@ -259,12 +261,6 @@ encoded as string, as follows:
 : The UA discovers that a device with {{BluetoothDevice/id}}
     <var>device-id</var> is no longer nearby.
 :: <code>"remove-device(<var>device-id</var>)"</code>
-
-Note: {{TestRunner/getBluetoothManualChooserEvents()}} returns a
-<code>sequence&lt;DOMString></code> rather than the
-<code>{{Promise}}&lt;sequence&lt;DOMString>></code> that we'd normally prefer
-because the Chromium implementation has layering issues that make it difficult
-to return a {{Promise}} from this interface.
 
 
 <h3 dfn-type="method" for="TestRunner">sendBluetoothManualChooserEvent(event, argument)</h3>

--- a/tests/index.html
+++ b/tests/index.html
@@ -1008,7 +1008,7 @@
   <div class="head">
    <div data-fill-with="logo"></div>
    <h1 class="p-name no-ref" id="title">Testing Web Bluetooth</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-09-17">17 September 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-09-23">23 September 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1103,10 +1103,12 @@ code may access them.</p>
 };
 </pre>
    <h2 class="heading settled" data-level="4" id="test-runner"><span class="secno">4. </span><span class="content">testRunner</span><a class="self-link" href="#test-runner"></a></h2>
-<pre class="idl">interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="testrunner">TestRunner<a class="self-link" href="#testrunner"></a></dfn> {
+<pre class="idl">callback <dfn class="idl-code" data-dfn-type="callback" data-export="" id="callbackdef-bluetoothmanualchoosereventscallback">BluetoothManualChooserEventsCallback<a class="self-link" href="#callbackdef-bluetoothmanualchoosereventscallback"></a></dfn> = void(sequence&lt;DOMString> <dfn class="idl-code" data-dfn-for="BluetoothManualChooserEventsCallback" data-dfn-type="argument" data-export="" id="dom-bluetoothmanualchoosereventscallback-events">events<a class="self-link" href="#dom-bluetoothmanualchoosereventscallback-events"></a></dfn>);
+
+interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="testrunner">TestRunner<a class="self-link" href="#testrunner"></a></dfn> {
   void <a class="idl-code" data-link-type="method" href="#dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet</a>(DOMString <dfn class="idl-code" data-dfn-for="TestRunner/setBluetoothMockDataSet(dataSetName)" data-dfn-type="argument" data-export="" id="dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName<a class="self-link" href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname"></a></dfn>);
   void <a class="idl-code" data-link-type="method" href="#dom-testrunner-setbluetoothmanualchooser">setBluetoothManualChooser</a>();
-  sequence&lt;DOMString> <a class="idl-code" data-link-type="method" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents</a>();
+  void <a class="idl-code" data-link-type="method" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents</a>(<a data-link-type="idl-name" href="#callbackdef-bluetoothmanualchoosereventscallback">BluetoothManualChooserEventsCallback</a> callback);
   void <a class="idl-code" data-link-type="method" href="#dom-testrunner-sendbluetoothmanualchooserevent">sendBluetoothManualChooserEvent</a>(DOMString <dfn class="idl-code" data-dfn-for="TestRunner/sendBluetoothManualChooserEvent(event, argument)" data-dfn-type="argument" data-export="" id="dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">event<a class="self-link" href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event"></a></dfn>, DOMString <dfn class="idl-code" data-dfn-for="TestRunner/sendBluetoothManualChooserEvent(event, argument)" data-dfn-type="argument" data-export="" id="dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">argument<a class="self-link" href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument"></a></dfn>);
 };
 </pre>
@@ -1222,8 +1224,8 @@ read or written, the characteristic with UUID <code>errorUUID(which)</code> retu
 prompt used in <code class="idl"><a data-link-type="idl" href="https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetooth-requestdevice">requestDevice()</a></code> with a "<dfn data-dfn-type="dfn" data-noexport="" id="manual-chooser">manual chooser<a class="self-link" href="#manual-chooser"></a></dfn>"
 that records events that would otherwise be shown to the user (see <code class="idl"><a data-link-type="idl" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents()</a></code>), and which can simulate user
 interaction with the prompt (see <code class="idl"><a data-link-type="idl" href="#dom-testrunner-sendbluetoothmanualchooserevent">sendBluetoothManualChooserEvent()</a></code>).</p>
-   <h3 class="heading settled idl-code" data-dfn-for="TestRunner" data-dfn-type="method" data-export="" data-level="4.3" data-lt="getBluetoothManualChooserEvents()" id="dom-testrunner-getbluetoothmanualchooserevents"><span class="secno">4.3. </span><span class="content">getBluetoothManualChooserEvents()</span><a class="self-link" href="#dom-testrunner-getbluetoothmanualchooserevents"></a></h3>
-   <p>When invoked, <code class="idl"><a data-link-type="idl" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents()</a></code> MUST return the
+   <h3 class="heading settled idl-code" data-dfn-for="TestRunner" data-dfn-type="method" data-export="" data-level="4.3" data-lt="getBluetoothManualChooserEvents(callback)" id="dom-testrunner-getbluetoothmanualchooserevents"><span class="secno">4.3. </span><span class="content">getBluetoothManualChooserEvents()</span><a class="self-link" href="#dom-testrunner-getbluetoothmanualchooserevents"></a></h3>
+   <p>When invoked, <code class="idl"><a data-link-type="idl" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents(callback)</a></code> MUST call <code>callback</code> with the
 list of events that have been recorded by the <a data-link-type="dfn" href="#manual-chooser">manual chooser</a> since <code class="idl"><a data-link-type="idl" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents()</a></code> was last called. Each event is
 encoded as string, as follows:</p>
    <dl>
@@ -1267,9 +1269,6 @@ devices.</p>
     <dd data-md="">
      <p><code>"remove-device(<var>device-id</var>)"</code></p>
    </dl>
-   <p class="note" role="note">Note: <code class="idl"><a data-link-type="idl" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents()</a></code> returns a <code>sequence&lt;DOMString></code> rather than the <code><code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/css-font-loading-3/#promise">Promise</a></code>&lt;sequence&lt;DOMString>></code> that we’d normally prefer
-because the Chromium implementation has layering issues that make it difficult
-to return a <code class="idl"><a data-link-type="idl" href="https://drafts.csswg.org/css-font-loading-3/#promise">Promise</a></code> from this interface.</p>
    <h3 class="heading settled idl-code" data-dfn-for="TestRunner" data-dfn-type="method" data-export="" data-level="4.4" data-lt="sendBluetoothManualChooserEvent(event, argument)" id="dom-testrunner-sendbluetoothmanualchooserevent"><span class="secno">4.4. </span><span class="content">sendBluetoothManualChooserEvent(event, argument)</span><a class="self-link" href="#dom-testrunner-sendbluetoothmanualchooserevent"></a></h3>
    <p>When invoked, <code class="idl"><a data-link-type="idl" href="#dom-testrunner-sendbluetoothmanualchooserevent">sendBluetoothManualChooserEvent(event, argument)</a></code> MUST cause the <a data-link-type="dfn" href="#manual-chooser">manual chooser</a> to inform the UA that the user has taken an
 action corresponding to the <code class="idl"><a data-link-type="idl" href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">event</a></code>:</p>
@@ -1316,15 +1315,17 @@ event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.o
    <li><a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">argument</a><span>, in §4</span>
    <li><a href="#basedevice">BaseDevice</a><span>, in §4.1</span>
    <li><a href="#batterydevice">BatteryDevice</a><span>, in §4.1.1</span>
+   <li><a href="#callbackdef-bluetoothmanualchoosereventscallback">BluetoothManualChooserEventsCallback</a><span>, in §4</span>
    <li><a href="#dom-eventsender-keydown-code-code">code</a><span>, in §5</span>
    <li><a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName</a><span>, in §4</span>
    <li><a href="#erroruuid-unsigned-long-id">errorUUID(unsigned long id)</a><span>, in §4.1.9</span>
    <li><a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">event</a><span>, in §4</span>
-   <li><a href="#dom-window-eventsender">eventSender</a><span>, in §3</span>
+   <li><a href="#dom-bluetoothmanualchoosereventscallback-events">events</a><span>, in §4</span>
    <li><a href="#eventsender">EventSender</a><span>, in §5</span>
+   <li><a href="#dom-window-eventsender">eventSender</a><span>, in §3</span>
    <li><a href="#failinggattoperationsdevice">FailingGATTOperationsDevice</a><span>, in §4.1.8</span>
    <li><a href="#genericaccessdevice">GenericAccessDevice</a><span>, in §4.1.7</span>
-   <li><a href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents()</a><span>, in §4.2</span>
+   <li><a href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents(callback)</a><span>, in §4.2</span>
    <li><a href="#glucosedevice">GlucoseDevice</a><span>, in §4.1.2</span>
    <li><a href="#heartratedevice">HeartRateDevice</a><span>, in §4.1.3</span>
    <li><a href="#dom-eventsender-keydown">keyDown(code)</a><span>, in §5</span>
@@ -1350,11 +1351,6 @@ event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.o
      <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.generic_access.xml#">org.bluetooth.service.generic_access</a>
      <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.glucose.xml#">org.bluetooth.service.glucose</a>
      <li><a href="https://developer.bluetooth.org/gatt/services/Pages/ServiceViewer.aspx?u=org.bluetooth.service.heart_rate.xml#">org.bluetooth.service.heart_rate</a>
-    </ul>
-   <li>
-    <a data-link-type="biblio" href="#biblio-css-font-loading-3">[css-font-loading-3]</a> defines the following terms:
-    <ul>
-     <li><a href="https://drafts.csswg.org/css-font-loading-3/#promise">Promise</a>
     </ul>
    <li>
     <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
@@ -1393,8 +1389,6 @@ event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.o
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-ui-events"><a class="self-link" href="#biblio-ui-events"></a>[UI-EVENTS]
    <dd>Gary Kacmarcik; Travis Leithead. <a href="http://www.w3.org/TR/uievents/">UI Events (formerly DOM Level 3 Events)</a>. 28 April 2015. WD. URL: <a href="http://www.w3.org/TR/uievents/">http://www.w3.org/TR/uievents/</a>
-   <dt id="biblio-css-font-loading-3"><a class="self-link" href="#biblio-css-font-loading-3"></a>[CSS-FONT-LOADING-3]
-   <dd>Tab Atkins Jr.. <a href="http://www.w3.org/TR/css-font-loading-3/">CSS Font Loading Module Level 3</a>. 22 May 2014. LCWD. URL: <a href="http://www.w3.org/TR/css-font-loading-3/">http://www.w3.org/TR/css-font-loading-3/</a>
    <dt id="biblio-rfc2119"><a class="self-link" href="#biblio-rfc2119"></a>[RFC2119]
    <dd>S. Bradner. <a href="https://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a>. March 1997. Best Current Practice. URL: <a href="https://tools.ietf.org/html/rfc2119">https://tools.ietf.org/html/rfc2119</a>
    <dt id="biblio-web-bluetooth"><a class="self-link" href="#biblio-web-bluetooth"></a>[WEB-BLUETOOTH]
@@ -1406,10 +1400,12 @@ event</a> named <code class="idl"><a data-link-type="idl" href="https://www.w3.o
   readonly attribute <a data-link-type="idl-name" href="#eventsender">EventSender</a> <a data-readonly="" data-type="EventSender " href="#dom-window-eventsender">eventSender</a>;
 };
 
+callback <a href="#callbackdef-bluetoothmanualchoosereventscallback">BluetoothManualChooserEventsCallback</a> = void(sequence&lt;DOMString> <a href="#dom-bluetoothmanualchoosereventscallback-events">events</a>);
+
 interface <a href="#testrunner">TestRunner</a> {
   void <a class="idl-code" data-link-type="method" href="#dom-testrunner-setbluetoothmockdataset">setBluetoothMockDataSet</a>(DOMString <a href="#dom-testrunner-setbluetoothmockdataset-datasetname-datasetname">dataSetName</a>);
   void <a class="idl-code" data-link-type="method" href="#dom-testrunner-setbluetoothmanualchooser">setBluetoothManualChooser</a>();
-  sequence&lt;DOMString> <a class="idl-code" data-link-type="method" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents</a>();
+  void <a class="idl-code" data-link-type="method" href="#dom-testrunner-getbluetoothmanualchooserevents">getBluetoothManualChooserEvents</a>(<a data-link-type="idl-name" href="#callbackdef-bluetoothmanualchoosereventscallback">BluetoothManualChooserEventsCallback</a> callback);
   void <a class="idl-code" data-link-type="method" href="#dom-testrunner-sendbluetoothmanualchooserevent">sendBluetoothManualChooserEvent</a>(DOMString <a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-event">event</a>, DOMString <a href="#dom-testrunner-sendbluetoothmanualchooserevent-event-argument-argument">argument</a>);
 };
 


### PR DESCRIPTION
This uses a callback rather than a promise because of an objection in
https://codereview.chromium.org/1351393002.

Preview at https://rawgit.com/jyasskin/web-bluetooth-1/async-get-events/tests/index.html#test-runner.