### PR TITLE
Allow filtering by device name and name prefix in requestDevice().

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -103,6 +103,7 @@ spec: dom-ls; urlPrefix: http://dom.spec.whatwg.org/#; type: dfn
 spec: ECMAScript; urlPrefix: http://ecma-international.org/ecma-262/6.0/#
     type: method
         text: Array.prototype.map; url: sec-array.prototype.map
+        text: String.prototype.startsWith; url: sec-string.prototype.startswith
     type: interface
         text: Array; url: sec-array-objects
         text: ArrayBuffer; url: sec-arraybuffer-constructor
@@ -112,6 +113,10 @@ spec: ECMAScript; urlPrefix: http://ecma-international.org/ecma-262/6.0/#
         text: Set; url: sec-set-objects
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
         text: TypedArray; url: sec-typedarray-constructors
+
+spec: encoding; urlPrefix: https://encoding.spec.whatwg.org/#
+    type: dfn
+        text: utf-8 decode without BOM; url: utf-8-decode-without-bom
 
 spec: powerful-features; urlPrefix: https://w3c.github.io/webappsec/specs/powerfulfeatures/#
     type: dfn
@@ -527,6 +532,8 @@ spec: html
   <pre class="idl">
     dictionary BluetoothScanFilter {
       sequence&lt;BluetoothServiceUUID> services;
+      DOMString name;
+      DOMString namePrefix;
     };
 
     dictionary RequestDeviceOptions {
@@ -545,11 +552,24 @@ spec: html
     <p>
       {{Bluetooth/requestDevice(options)}} asks the user
       to grant this origin access to a device
-      that <a>matches a filter</a> in <code>options.<dfn dict-member for="RequestDeviceOptions">filters</dfn></code>.
-      The user will be shown devices that support
-      <em>all</em> the GATT service UUIDs in the <dfn dict-member for="BluetoothScanFilter">services</dfn> list
-      of <em>any</em> {{BluetoothScanFilter}} in <code>filters</code>.
+      that <a>matches any filter</a> in <code>options.<dfn dict-member for="RequestDeviceOptions">filters</dfn></code>.
+      To <a>match a filter</a>, the device has to:
     </p>
+    <ul>
+      <li>
+        support <em>all</em> the GATT service UUIDs
+        in the <dfn dict-member for="BluetoothScanFilter">services</dfn> list
+        if that member is present,
+      </li>
+      <li>
+        have a name equal to <dfn dict-member for="BluetoothScanFilter">name</dfn>
+        if that member is present, and
+      </li>
+      <li>
+        have a name starting with <dfn dict-member for="BluetoothScanFilter">namePrefix</dfn>
+        if that member is present.
+      </li>
+    </ul>
     <p>
       After the user selects a device to pair with this origin,
       the origin is allowed to access to any service whose UUID was listed
@@ -559,7 +579,7 @@ spec: html
     </p>
   </div>
 
-  <div class="example">
+  <div class="example" id="example-filter-by-services">
     <p>
       Say the UA is close to the following devices:
     </p>
@@ -569,6 +589,7 @@ spec: html
       <tr><td>D2</td><td>A, B, E</td></tr>
       <tr><td>D3</td><td>C, D</td></tr>
       <tr><td>D4</td><td>E</td></tr>
+      <tr><td>D5</td><td><i>&lt;none></i></td></tr>
     </table>
     <p>
       If the website calls
@@ -624,14 +645,120 @@ spec: html
       and the web page will be able to access service E.
     </p>
   </div>
+  <div class="example" id="example-filter-by-name">
+    <p>
+      Say the devices in the <a href="#example-filter-by-services">previous example</a>
+      also advertise names as follows:
+    </p>
+    <table>
+      <tr><th>Device</th><th>Advertised Device Name</th></tr>
+      <tr><td>D1</td><td>First De…</td></tr>
+      <tr><td>D2</td><td><i>&lt;none></i></td></tr>
+      <tr><td>D3</td><td>Device Third</td></tr>
+      <tr><td>D4</td><td>Device Fourth</td></tr>
+      <tr><td>D5</td><td>Unique Name</td></tr>
+    </table>
+
+    <p>
+      The following table shows which devices the user can select between
+      for several values of <var>filters</var> passed to
+      <code>navigator.bluetooth.requestDevice({filters: <var>filters</var>})</code>.
+    </p>
+
+    <table>
+      <tr><th><var>filters</var></th><th>Devices</th><th>Notes</th></tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{name: "Unique Name"}]
+          </pre>
+        </td>
+        <td>D5</td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{namePrefix: "Device"}]
+          </pre>
+        </td>
+        <td>D3, D4</td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{name: "First De"},
+             {name: "First Device"}]
+          </pre>
+        </td>
+        <td><i>&lt;none></i></td>
+        <td>
+          D1 only advertises a prefix of its name,
+          so trying to match its whole name fails.
+        </td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{namePrefix: ""}]
+          </pre>
+        </td>
+        <td>D1, D2, D3, D4, D5</td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{namePrefix: "First"},
+             {name: "Unique Name"}]
+          </pre>
+        </td>
+        <td>D1, D5</td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{services: \[C],
+              namePrefix: "Device"},
+             {name: "Unique Name"}]
+          </pre>
+        </td>
+        <td>D3, D5</td>
+      </tr>
+    </table>
+
+    <p>
+      Remember to use {{RequestDeviceOptions/optionalServices}} to get access to services
+      if you only filter by name.
+    </p>
+  </div>
 
   <p>
-    A device <dfn local-lt="match a filter">matches a filter</dfn> <var>filter</var> if
-    the UA has received advertising data, an <a>extended inquiry response</a>,
-    or a service discovery response indicating that
-    the device supports each of the <a>Service</a> UUIDs
-    included in <code><var>filter</var>.services</code> as a primary (vs included) service.
+    A <a>Bluetooth device</a> <var>device</var>
+    <dfn local-lt="match a filter|matches any filter">matches a filter</dfn> <var>filter</var>
+    if the following steps return `match`:
   </p>
+  <ol>
+    <li>
+      If <code><var>filter</var>.name</code> is present then,
+      if <var>device</var>'s <a>Bluetooth Device Name</a> isn't complete
+      and equal to <code><var>filter</var>.name</code>,
+      return `mismatch`.
+    </li>
+    <li>
+      If <code><var>filter</var>.namePrefix</code> is present then
+      let <var>deviceName</var> be <var>device</var>'s partial or complete <a>Bluetooth Device Name</a>,
+      or `""` if <var>device</var>'s <a>Bluetooth Device Name</a> is absent.
+      If <code><var>deviceName</var>.{{String.prototype.startsWith|startsWith}}(<var>filter</var>.namePrefix)</code> is `false`,
+      return `mismatch`.
+    </li>
+    <li>
+      For each <var>uuid</var> in <code><var>filter</var>.services</code>,
+      if the UA has not received advertising data, an <a>extended inquiry response</a>,
+      or a service discovery response indicating that
+      the device supports a primary (vs included) service with UUID <var>uuid</var>,
+      return `mismatch`.
+    </li>
+    <li>Return `match`.
+  </ol>
 
   <p class="note">
     The list of Service UUIDs that a device advertises
@@ -669,27 +796,46 @@ spec: html
           For each <var>filter</var> in <code><var>options</var>.filters</code>,
           do the following steps:
           <ol>
+            <li>Let <var>canonicalizedFilter</var> be `{}`.</li>
             <li>
-              If <code><var>filter</var>.services.length === 0</code>,
-              <a>reject</a> <var>promise</var> with a {{TypeError}}
-              and abort these steps.
-            </li>
-            <li>
-              Let <var>services</var> be
-              <code>{{Array.prototype.map}}.call(<var>filter</var>.services,
+              If <code><var>filter</var>.services</code> is present, do the following sub-steps:
+              <ol>
+                <li>
+                  If <code><var>filter</var>.services.length === 0</code>,
+                  <a>reject</a> <var>promise</var> with a {{TypeError}}
+                  and abort these steps.
+                </li>
+                <li>
+                  Let <var>services</var> be
+                  <code>{{Array.prototype.map}}.call(<var>filter</var>.services,
                 {{BluetoothUUID/getService()|BluetoothUUID.getService}})</code>.
+                </li>
+                <li>
+                  If any of the {{BluetoothUUID/getService()|BluetoothUUID.getService()}} calls threw an exception,
+                  <a>reject</a> <var>promise</var> with that exception and abort these steps.
+                </li>
+                <li>
+                  If any <var>service</var> in <var>services</var> is <a>blacklisted</a>,
+                  <a>reject</a> <var>promise</var> with a {{SecurityError}}
+                  and abort these steps.
+                </li>
+                <li>
+                  Set <code><var>canonicalizedFilter</var>.services</code> to <var>services</var>.
+                </li>
+                <li>Add the elements of <var>services</var> to <var>requiredServiceUUIDs</var>.</li>
+              </ol>
             </li>
             <li>
-              If any of the {{BluetoothUUID/getService()|BluetoothUUID.getService()}} calls threw an exception,
-              <a>reject</a> <var>promise</var> with that exception and abort these steps.
+              If <code><var>filter</var>.name</code> is present,
+              set <code><var>canonicalizedFilter</var>.name</code>
+              to <code><var>filter</var>.name</code>.
             </li>
             <li>
-              If any <var>service</var> in <var>services</var> is <a>blacklisted</a>,
-              <a>reject</a> <var>promise</var> with a {{SecurityError}}
-              and abort these steps.
+              If <code><var>filter</var>.namePrefix</code> is present,
+              set <code><var>canonicalizedFilter</var>.namePrefix</code>
+              to <code><var>filter</var>.namePrefix</code>.
             </li>
-            <li>Append <code>{services: <var>services</var>}</code> to <var>uuidFilters</var>.</li>
-            <li>Add the elements of <var>services</var> to <var>requiredServiceUUIDs</var>.</li>
+            <li>Append <var>canonicalizedFilter</var> to <var>uuidFilters</var>.</li>
           </ol>
         </li>
         <li>
@@ -898,6 +1044,8 @@ spec: html
         An optional partial or complete <a>Bluetooth Device Name</a>.
         A device has a partial name when the <a>Shortened Local Name</a> AD data was received,
         but the full name hasn't been read yet.
+        When the <a>Bluetooth Device Name</a> is encoded as UTF-8 and
+        converted to a DOMString using the <a>utf-8 decode without BOM</a> algorithm.
       </li>
 
       <li>

--- a/index.bs
+++ b/index.bs
@@ -116,6 +116,7 @@ spec: ECMAScript; urlPrefix: http://ecma-international.org/ecma-262/6.0/#
 spec: encoding; urlPrefix: https://encoding.spec.whatwg.org/#
     type: dfn
         text: utf-8 decode without BOM; url: utf-8-decode-without-bom
+        text: utf-8 encode; url: utf-8-encode
 
 spec: powerful-features; urlPrefix: https://w3c.github.io/webappsec/specs/powerfulfeatures/#
     type: dfn
@@ -840,17 +841,41 @@ spec: html
               </ol>
             </li>
             <li>
-              If <code><var>filter</var>.name</code> is present,
-              set <code><var>canonicalizedFilter</var>.name</code>
-              to <code><var>filter</var>.name</code>.
+              If <code><var>filter</var>.name</code> is present, do the following sub-steps.
+              <ol>
+                <li>
+                  If the <a lt="utf-8 encode">UTF-8 encoding</a>
+                  of <code><var>filter</var>.name</code>
+                  is more than 248 bytes long,
+                  <a>reject</a> <var>promise</var> with a {{TypeError}}
+                  and abort these steps.
+
+                  <p class="note">
+                    248 is the maximum number of UTF-8 code units in
+                    a <a>Bluetooth Device Name</a>.
+                  </p>
+                </li>
+                <li>
+                  Set <code><var>canonicalizedFilter</var>.name</code>
+                  to <code><var>filter</var>.name</code>.
+                </li>
+              </ol>
             </li>
             <li>
               If <code><var>filter</var>.namePrefix</code> is present, do the following sub-steps.
               <ol>
                 <li>
-                  If <code><var>filter</var>.namePrefix.length === 0</code>,
+                  If <code><var>filter</var>.namePrefix.length === 0</code>
+                  or if the <a lt="utf-8 encode">UTF-8 encoding</a>
+                  of <code><var>filter</var>.namePrefix</code>
+                  is more than 248 bytes long,
                   <a>reject</a> <var>promise</var> with a {{TypeError}}
                   and abort these steps.
+
+                  <p class="note">
+                    248 is the maximum number of UTF-8 code units in
+                    a <a>Bluetooth Device Name</a>.
+                  </p>
                 </li>
                 <li>
                   Set <code><var>canonicalizedFilter</var>.namePrefix</code>

--- a/index.bs
+++ b/index.bs
@@ -103,7 +103,6 @@ spec: dom-ls; urlPrefix: http://dom.spec.whatwg.org/#; type: dfn
 spec: ECMAScript; urlPrefix: http://ecma-international.org/ecma-262/6.0/#
     type: method
         text: Array.prototype.map; url: sec-array.prototype.map
-        text: String.prototype.startsWith; url: sec-string.prototype.startswith
     type: interface
         text: Array; url: sec-array-objects
         text: ArrayBuffer; url: sec-arraybuffer-constructor
@@ -699,14 +698,6 @@ spec: html
       <tr>
         <td>
           <pre highlight="js">
-            [{namePrefix: ""}]
-          </pre>
-        </td>
-        <td>D1, D2, D3, D4, D5</td>
-      </tr>
-      <tr>
-        <td>
-          <pre highlight="js">
             [{namePrefix: "First"},
              {name: "Unique Name"}]
           </pre>
@@ -722,6 +713,24 @@ spec: html
           </pre>
         </td>
         <td>D3, D5</td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{}]
+          </pre>
+        </td>
+        <td><i>TypeError</i></td>
+        <td>A filter must restrict the devices in some way.</td>
+      </tr>
+      <tr>
+        <td>
+          <pre highlight="js">
+            [{namePrefix: ""}]
+          </pre>
+        </td>
+        <td><i>TypeError</i></td>
+        <td>A filter must restrict the devices in some way.</td>
       </tr>
     </table>
 
@@ -745,9 +754,8 @@ spec: html
     </li>
     <li>
       If <code><var>filter</var>.namePrefix</code> is present then
-      let <var>deviceName</var> be <var>device</var>'s partial or complete <a>Bluetooth Device Name</a>,
-      or `""` if <var>device</var>'s <a>Bluetooth Device Name</a> is absent.
-      If <code><var>deviceName</var>.{{String.prototype.startsWith|startsWith}}(<var>filter</var>.namePrefix)</code> is `false`,
+      if <var>device</var>'s <a>Bluetooth Device Name</a> isn't present
+      or doesn't start with <code><var>filter</var>.namePrefix</code>,
       return `mismatch`.
     </li>
     <li>
@@ -796,6 +804,12 @@ spec: html
           For each <var>filter</var> in <code><var>options</var>.filters</code>,
           do the following steps:
           <ol>
+            <li>
+              If none of <var>filter</var>'s
+              <code>services</code>, <code>name</code>, or <code>namePrefix</code> members is present,
+              <a>reject</a> <var>promise</var> with a {{TypeError}}
+              and abort these steps.
+            </li>
             <li>Let <var>canonicalizedFilter</var> be `{}`.</li>
             <li>
               If <code><var>filter</var>.services</code> is present, do the following sub-steps:
@@ -831,9 +845,18 @@ spec: html
               to <code><var>filter</var>.name</code>.
             </li>
             <li>
-              If <code><var>filter</var>.namePrefix</code> is present,
-              set <code><var>canonicalizedFilter</var>.namePrefix</code>
-              to <code><var>filter</var>.namePrefix</code>.
+              If <code><var>filter</var>.namePrefix</code> is present, do the following sub-steps.
+              <ol>
+                <li>
+                  If <code><var>filter</var>.namePrefix.length === 0</code>,
+                  <a>reject</a> <var>promise</var> with a {{TypeError}}
+                  and abort these steps.
+                </li>
+                <li>
+                  Set <code><var>canonicalizedFilter</var>.namePrefix</code>
+                  to <code><var>filter</var>.namePrefix</code>.
+                </li>
+              </ol>
             </li>
             <li>Append <var>canonicalizedFilter</var> to <var>uuidFilters</var>.</li>
           </ol>

--- a/index.bs
+++ b/index.bs
@@ -576,6 +576,11 @@ spec: html
       in any element of <code>options.filters</code>
       or in <code>options.<dfn dict-member for="RequestDeviceOptions">optionalServices</dfn></code>.
     </p>
+
+    <p>
+      This implies that if developers filter just by name,
+      they must use {{RequestDeviceOptions/optionalServices}} to get access to any services.
+    </p>
   </div>
 
   <div class="example" id="example-filter-by-services">
@@ -730,14 +735,9 @@ spec: html
           </pre>
         </td>
         <td><i>TypeError</i></td>
-        <td>A filter must restrict the devices in some way.</td>
+        <td>`namePrefix`, if present, must be non-empty to filter devices.</td>
       </tr>
     </table>
-
-    <p>
-      Remember to use {{RequestDeviceOptions/optionalServices}} to get access to services
-      if you only filter by name.
-    </p>
   </div>
 
   <p>
@@ -1067,7 +1067,7 @@ spec: html
         An optional partial or complete <a>Bluetooth Device Name</a>.
         A device has a partial name when the <a>Shortened Local Name</a> AD data was received,
         but the full name hasn't been read yet.
-        When the <a>Bluetooth Device Name</a> is encoded as UTF-8 and
+        The <a>Bluetooth Device Name</a> is encoded as UTF-8 and
         converted to a DOMString using the <a>utf-8 decode without BOM</a> algorithm.
       </li>
 

--- a/index.html
+++ b/index.html
@@ -1065,7 +1065,7 @@
   <div class="head">
    <div data-fill-with="logo"></div>
    <h1 class="p-name no-ref" id="title">Web Bluetooth</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-10-13">13 October 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-10-14">14 October 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1592,10 +1592,6 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
           so trying to match its whole name fails. 
        <tr>
         <td>
-<pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">""</span><span class="p">}]</span></pre>
-        <td>D1, D2, D3, D4, D5
-       <tr>
-        <td>
 <pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">"First"</span><span class="p">},</span>
  <span class="p">{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"Unique Name"</span><span class="p">}]</span></pre>
         <td>D1, D5
@@ -1605,6 +1601,16 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
   <span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">"Device"</span><span class="p">},</span>
  <span class="p">{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"Unique Name"</span><span class="p">}]</span></pre>
         <td>D3, D5
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{}]</span></pre>
+        <td><i>TypeError</i>
+        <td>A filter must restrict the devices in some way.
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">""</span><span class="p">}]</span></pre>
+        <td><i>TypeError</i>
+        <td>A filter must restrict the devices in some way.
      </table>
      <p> Remember to use <code class="idl"><a data-link-type="idl" href="#dom-requestdeviceoptions-optionalservices">optionalServices</a></code> to get access to services
       if you only filter by name. </p>
@@ -1616,9 +1622,8 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
       and equal to <code><var>filter</var>.name</code>,
       return <code>mismatch</code>. 
      <li> If <code><var>filter</var>.namePrefix</code> is present then
-      let <var>deviceName</var> be <var>device</var>’s partial or complete <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a>,
-      or <code>""</code> if <var>device</var>’s <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> is absent.
-      If <code><var>deviceName</var>.<code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-string.prototype.startswith">startsWith</a></code>(<var>filter</var>.namePrefix)</code> is <code>false</code>,
+      if <var>device</var>’s <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> isn’t present
+      or doesn’t start with <code><var>filter</var>.namePrefix</code>,
       return <code>mismatch</code>. 
      <li> For each <var>uuid</var> in <code><var>filter</var>.services</code>,
       if the UA has not received advertising data, an <a data-link-type="dfn" href="#extended-inquiry-response">extended inquiry response</a>,
@@ -1648,6 +1653,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
          For each <var>filter</var> in <code><var>options</var>.filters</code>,
           do the following steps: 
         <ol>
+         <li> If none of <var>filter</var>’s <code>services</code>, <code>name</code>, or <code>namePrefix</code> members is present, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
          <li>Let <var>canonicalizedFilter</var> be <code>{}</code>.
          <li>
            If <code><var>filter</var>.services</code> is present, do the following sub-steps: 
@@ -1661,8 +1667,12 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
           </ol>
          <li> If <code><var>filter</var>.name</code> is present,
               set <code><var>canonicalizedFilter</var>.name</code> to <code><var>filter</var>.name</code>. 
-         <li> If <code><var>filter</var>.namePrefix</code> is present,
-              set <code><var>canonicalizedFilter</var>.namePrefix</code> to <code><var>filter</var>.namePrefix</code>. 
+         <li>
+           If <code><var>filter</var>.namePrefix</code> is present, do the following sub-steps. 
+          <ol>
+           <li> If <code><var>filter</var>.namePrefix.length === 0</code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
+           <li> Set <code><var>canonicalizedFilter</var>.namePrefix</code> to <code><var>filter</var>.namePrefix</code>. 
+          </ol>
          <li>Append <var>canonicalizedFilter</var> to <var>uuidFilters</var>.
         </ol>
        <li> Let <var>optionalServiceUUIDs</var> be <code><code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-array.prototype.map">Array.prototype.map</a></code>.call(<var>options</var>.optionalServices, <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService</a></code>)</code>. 
@@ -3680,7 +3690,6 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-map-constructor">Map</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-promise-objects">Promise</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-set-objects">Set</a>
-     <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-string.prototype.startswith">String.prototype.startsWith</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-typedarray-constructors">TypedArray</a>
     </ul>

--- a/index.html
+++ b/index.html
@@ -962,6 +962,13 @@
 		font-weight: bold;
 	}
 
+/** Extra-large Elements ******************************************************/
+
+	.big-element-wrapper {
+		max-width: 50em;
+		overflow-x: auto;
+	}
+
 /******************************************************************************/
 /*                                    Print                                   */
 /******************************************************************************/
@@ -1065,7 +1072,7 @@
   <div class="head">
    <div data-fill-with="logo"></div>
    <h1 class="p-name no-ref" id="title">Web Bluetooth</h1>
-   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-10-14">14 October 2015</time></span></h2>
+   <h2 class="no-num no-toc no-ref heading settled" id="subtitle"><span class="content">Draft Community Group Report, <time class="dt-updated" datetime="2015-10-30">30 October 2015</time></span></h2>
    <div data-fill-with="spec-metadata">
     <dl>
      <dt>This version:
@@ -1484,6 +1491,8 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
       the origin is allowed to access to any service whose UUID was listed
       in the <code class="idl"><a data-link-type="idl" href="#dom-bluetoothscanfilter-services">services</a></code> list
       in any element of <code>options.filters</code> or in <code>options.<dfn class="idl-code" data-dfn-for="RequestDeviceOptions" data-dfn-type="dict-member" data-export="" id="dom-requestdeviceoptions-optionalservices">optionalServices<a class="self-link" href="#dom-requestdeviceoptions-optionalservices"></a></dfn></code>. </p>
+     <p> This implies that if developers filter just by name,
+      they must use <code class="idl"><a data-link-type="idl" href="#dom-requestdeviceoptions-optionalservices">optionalServices</a></code> to get access to any services. </p>
     </div>
     <div class="example" id="example-filter-by-services">
      <a class="self-link" href="#example-filter-by-services"></a> 
@@ -1610,10 +1619,8 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
         <td>
 <pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">""</span><span class="p">}]</span></pre>
         <td><i>TypeError</i>
-        <td>A filter must restrict the devices in some way.
+        <td><code>namePrefix</code>, if present, must be non-empty to filter devices.
      </table>
-     <p> Remember to use <code class="idl"><a data-link-type="idl" href="#dom-requestdeviceoptions-optionalservices">optionalServices</a></code> to get access to services
-      if you only filter by name. </p>
     </div>
     <p> A <a data-link-type="dfn" href="#bluetooth-device">Bluetooth device</a> <var>device</var> <dfn data-dfn-type="dfn" data-local-lt="match a filter|matches any filter" data-noexport="" id="matches-a-filter">matches a filter<a class="self-link" href="#matches-a-filter"></a></dfn> <var>filter</var> if the following steps return <code>match</code>: </p>
     <ol>
@@ -1788,7 +1795,7 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
       <li> An optional partial or complete <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a>.
         A device has a partial name when the <a data-link-type="dfn" href="https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile#">Shortened Local Name</a> AD data was received,
         but the full name hasn’t been read yet.
-        When the <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> is encoded as UTF-8 and
+        The <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> is encoded as UTF-8 and
         converted to a DOMString using the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">utf-8 decode without BOM</a> algorithm. 
       <li> An <a data-link-type="dfn" href="#att-bearer">ATT Bearer</a>, over which all GATT communication happens.
         The <a data-link-type="dfn" href="#att-bearer">ATT Bearer</a> is created by procedures described in
@@ -3766,7 +3773,7 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
    <dt id="biblio-bluetooth42"><a class="self-link" href="#biblio-bluetooth42"></a>[BLUETOOTH42]
    <dd><a href="https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439">BLUETOOTH SPECIFICATION Version 4.2</a>. 2 December 2014. URL: <a href="https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439">https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=286439</a>
    <dt id="biblio-ecmascript"><a class="self-link" href="#biblio-ecmascript"></a>[ECMASCRIPT]
-   <dd>Allen Wirfs-Brock. <a href="http://www.ecma-international.org/ecma-262/6.0/">ECMA-262 6th Edition, The ECMAScript 2015 Language Specification</a>. June 2015. Standard. URL: <a href="http://www.ecma-international.org/ecma-262/6.0/">http://www.ecma-international.org/ecma-262/6.0/</a>
+   <dd><a href="https://tc39.github.io/ecma262/">ECMAScript Language Specification</a>. URL: <a href="https://tc39.github.io/ecma262/">https://tc39.github.io/ecma262/</a>
    <dt id="biblio-html"><a class="self-link" href="#biblio-html"></a>[HTML]
    <dd>Ian Hickson. <a href="https://html.spec.whatwg.org/multipage/">HTML Standard</a>. Living Standard. URL: <a href="https://html.spec.whatwg.org/multipage/">https://html.spec.whatwg.org/multipage/</a>
    <dt id="biblio-webidl"><a class="self-link" href="#biblio-webidl"></a>[WebIDL]
@@ -3774,7 +3781,7 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
    <dt id="biblio-dom-ls"><a class="self-link" href="#biblio-dom-ls"></a>[DOM-LS]
    <dd>Document Object Model URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
    <dt id="biblio-encoding"><a class="self-link" href="#biblio-encoding"></a>[ENCODING]
-   <dd>Anne van Kesteren; Joshua Bell; Addison Phillips. <a href="http://www.w3.org/TR/encoding/">Encoding</a>. 16 September 2014. CR. URL: <a href="http://www.w3.org/TR/encoding/">http://www.w3.org/TR/encoding/</a>
+   <dd>Anne van Kesteren; Joshua Bell; Addison Phillips. <a href="http://www.w3.org/TR/encoding/">Encoding</a>. 20 October 2015. CR. URL: <a href="http://www.w3.org/TR/encoding/">http://www.w3.org/TR/encoding/</a>
    <dt id="biblio-powerful-features"><a class="self-link" href="#biblio-powerful-features"></a>[POWERFUL-FEATURES]
    <dd>Mike West; Yan Zhu. <a href="http://www.w3.org/TR/powerful-features/">Privileged Contexts</a>. 24 April 2015. WD. URL: <a href="http://www.w3.org/TR/powerful-features/">http://www.w3.org/TR/powerful-features/</a>
    <dt id="biblio-promises-guide"><a class="self-link" href="#biblio-promises-guide"></a>[PROMISES-GUIDE]

--- a/index.html
+++ b/index.html
@@ -1672,12 +1672,22 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
            <li> Set <code><var>canonicalizedFilter</var>.services</code> to <var>services</var>. 
            <li>Add the elements of <var>services</var> to <var>requiredServiceUUIDs</var>.
           </ol>
-         <li> If <code><var>filter</var>.name</code> is present,
-              set <code><var>canonicalizedFilter</var>.name</code> to <code><var>filter</var>.name</code>. 
+         <li>
+           If <code><var>filter</var>.name</code> is present, do the following sub-steps. 
+          <ol>
+           <li>
+             If the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode">UTF-8 encoding</a> of <code><var>filter</var>.name</code> is more than 248 bytes long, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
+            <p class="note" role="note"> 248 is the maximum number of UTF-8 code units in
+                    a <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a>. </p>
+           <li> Set <code><var>canonicalizedFilter</var>.name</code> to <code><var>filter</var>.name</code>. 
+          </ol>
          <li>
            If <code><var>filter</var>.namePrefix</code> is present, do the following sub-steps. 
           <ol>
-           <li> If <code><var>filter</var>.namePrefix.length === 0</code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
+           <li>
+             If <code><var>filter</var>.namePrefix.length === 0</code> or if the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-encode">UTF-8 encoding</a> of <code><var>filter</var>.namePrefix</code> is more than 248 bytes long, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
+            <p class="note" role="note"> 248 is the maximum number of UTF-8 code units in
+                    a <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a>. </p>
            <li> Set <code><var>canonicalizedFilter</var>.namePrefix</code> to <code><var>filter</var>.namePrefix</code>. 
           </ol>
          <li>Append <var>canonicalizedFilter</var> to <var>uuidFilters</var>.
@@ -3725,6 +3735,7 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
     <a data-link-type="biblio" href="#biblio-encoding">[encoding]</a> defines the following terms:
     <ul>
      <li><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">utf-8 decode without bom</a>
+     <li><a href="https://encoding.spec.whatwg.org/#utf-8-encode">utf-8 encode</a>
     </ul>
    <li>
     <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:

--- a/index.html
+++ b/index.html
@@ -1451,6 +1451,8 @@ function onHeartRateChanged(event) {
     <h2 class="heading settled" data-level="3" id="device-discovery"><span class="secno">3. </span><span class="content">Device Discovery</span><a class="self-link" href="#device-discovery"></a></h2>
 <pre class="idl">dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-bluetoothscanfilter">BluetoothScanFilter<a class="self-link" href="#dictdef-bluetoothscanfilter"></a></dfn> {
   sequence&lt;<a data-link-type="idl-name" href="#typedefdef-bluetoothserviceuuid">BluetoothServiceUUID</a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<BluetoothServiceUUID> " href="#dom-bluetoothscanfilter-services">services</a>;
+  DOMString <a class="idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-bluetoothscanfilter-name">name</a>;
+  DOMString <a class="idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-bluetoothscanfilter-nameprefix">namePrefix</a>;
 };
 
 dictionary <dfn class="idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-requestdeviceoptions">RequestDeviceOptions<a class="self-link" href="#dictdef-requestdeviceoptions"></a></dfn> {
@@ -1469,16 +1471,22 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
      <div class="marker">NOTE: Bluetooth members</div>
      <p> <code class="idl"><a data-link-type="idl" href="#dom-bluetooth-requestdevice">requestDevice(options)</a></code> asks the user
       to grant this origin access to a device
-      that <a data-link-type="dfn" href="#matches-a-filter">matches a filter</a> in <code>options.<dfn class="idl-code" data-dfn-for="RequestDeviceOptions" data-dfn-type="dict-member" data-export="" id="dom-requestdeviceoptions-filters">filters<a class="self-link" href="#dom-requestdeviceoptions-filters"></a></dfn></code>.
-      The user will be shown devices that support <em>all</em> the GATT service UUIDs in the <dfn class="idl-code" data-dfn-for="BluetoothScanFilter" data-dfn-type="dict-member" data-export="" id="dom-bluetoothscanfilter-services">services<a class="self-link" href="#dom-bluetoothscanfilter-services"></a></dfn> list
-      of <em>any</em> <code class="idl"><a data-link-type="idl" href="#dictdef-bluetoothscanfilter">BluetoothScanFilter</a></code> in <code>filters</code>. </p>
+      that <a data-link-type="dfn" href="#matches-a-filter">matches any filter</a> in <code>options.<dfn class="idl-code" data-dfn-for="RequestDeviceOptions" data-dfn-type="dict-member" data-export="" id="dom-requestdeviceoptions-filters">filters<a class="self-link" href="#dom-requestdeviceoptions-filters"></a></dfn></code>.
+      To <a data-link-type="dfn" href="#matches-a-filter">match a filter</a>, the device has to: </p>
+     <ul>
+      <li> support <em>all</em> the GATT service UUIDs
+        in the <dfn class="idl-code" data-dfn-for="BluetoothScanFilter" data-dfn-type="dict-member" data-export="" id="dom-bluetoothscanfilter-services">services<a class="self-link" href="#dom-bluetoothscanfilter-services"></a></dfn> list
+        if that member is present, 
+      <li> have a name equal to <dfn class="idl-code" data-dfn-for="BluetoothScanFilter" data-dfn-type="dict-member" data-export="" id="dom-bluetoothscanfilter-name">name<a class="self-link" href="#dom-bluetoothscanfilter-name"></a></dfn> if that member is present, and 
+      <li> have a name starting with <dfn class="idl-code" data-dfn-for="BluetoothScanFilter" data-dfn-type="dict-member" data-export="" id="dom-bluetoothscanfilter-nameprefix">namePrefix<a class="self-link" href="#dom-bluetoothscanfilter-nameprefix"></a></dfn> if that member is present. 
+     </ul>
      <p> After the user selects a device to pair with this origin,
       the origin is allowed to access to any service whose UUID was listed
       in the <code class="idl"><a data-link-type="idl" href="#dom-bluetoothscanfilter-services">services</a></code> list
       in any element of <code>options.filters</code> or in <code>options.<dfn class="idl-code" data-dfn-for="RequestDeviceOptions" data-dfn-type="dict-member" data-export="" id="dom-requestdeviceoptions-optionalservices">optionalServices<a class="self-link" href="#dom-requestdeviceoptions-optionalservices"></a></dfn></code>. </p>
     </div>
-    <div class="example" id="example-c95583e2">
-     <a class="self-link" href="#example-c95583e2"></a> 
+    <div class="example" id="example-filter-by-services">
+     <a class="self-link" href="#example-filter-by-services"></a> 
      <p> Say the UA is close to the following devices: </p>
      <table>
       <tbody>
@@ -1497,6 +1505,9 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
        <tr>
         <td>D4
         <td>E
+       <tr>
+        <td>D5
+        <td><i>&lt;none></i>
      </table>
      <p> If the website calls </p>
 <pre class="highlight"><span class="nx">navigator</span><span class="p">.</span><span class="nx">bluetooth</span><span class="p">.</span><span class="nx">requestDevice</span><span class="p">({</span>
@@ -1532,11 +1543,90 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
       that will fire the <code class="idl"><a data-link-type="idl" href="#dom-bluetoothgattservice-serviceadded">serviceadded</a></code> event,
       and the web page will be able to access service E. </p>
     </div>
-    <p> A device <dfn data-dfn-type="dfn" data-local-lt="match a filter" data-noexport="" id="matches-a-filter">matches a filter<a class="self-link" href="#matches-a-filter"></a></dfn> <var>filter</var> if
-    the UA has received advertising data, an <a data-link-type="dfn" href="#extended-inquiry-response">extended inquiry response</a>,
-    or a service discovery response indicating that
-    the device supports each of the <a data-link-type="dfn" href="#service">Service</a> UUIDs
-    included in <code><var>filter</var>.services</code> as a primary (vs included) service. </p>
+    <div class="example" id="example-filter-by-name">
+     <a class="self-link" href="#example-filter-by-name"></a> 
+     <p> Say the devices in the <a href="#example-filter-by-services">previous example</a> also advertise names as follows: </p>
+     <table>
+      <tbody>
+       <tr>
+        <th>Device
+        <th>Advertised Device Name
+       <tr>
+        <td>D1
+        <td>First De…
+       <tr>
+        <td>D2
+        <td><i>&lt;none></i>
+       <tr>
+        <td>D3
+        <td>Device Third
+       <tr>
+        <td>D4
+        <td>Device Fourth
+       <tr>
+        <td>D5
+        <td>Unique Name
+     </table>
+     <p> The following table shows which devices the user can select between
+      for several values of <var>filters</var> passed to <code>navigator.bluetooth.requestDevice({filters: <var>filters</var>})</code>. </p>
+     <table>
+      <tbody>
+       <tr>
+        <th><var>filters</var>
+        <th>Devices
+        <th>Notes
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"Unique Name"</span><span class="p">}]</span></pre>
+        <td>D5
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">"Device"</span><span class="p">}]</span></pre>
+        <td>D3, D4
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"First De"</span><span class="p">},</span>
+ <span class="p">{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"First Device"</span><span class="p">}]</span></pre>
+        <td><i>&lt;none></i>
+        <td> D1 only advertises a prefix of its name,
+          so trying to match its whole name fails. 
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">""</span><span class="p">}]</span></pre>
+        <td>D1, D2, D3, D4, D5
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">"First"</span><span class="p">},</span>
+ <span class="p">{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"Unique Name"</span><span class="p">}]</span></pre>
+        <td>D1, D5
+       <tr>
+        <td>
+<pre class="highlight"><span class="p">[{</span><span class="nx">services</span><span class="o">:</span> <span class="p">[</span><span class="nx">C</span><span class="p">],</span>
+  <span class="nx">namePrefix</span><span class="o">:</span> <span class="s2">"Device"</span><span class="p">},</span>
+ <span class="p">{</span><span class="nx">name</span><span class="o">:</span> <span class="s2">"Unique Name"</span><span class="p">}]</span></pre>
+        <td>D3, D5
+     </table>
+     <p> Remember to use <code class="idl"><a data-link-type="idl" href="#dom-requestdeviceoptions-optionalservices">optionalServices</a></code> to get access to services
+      if you only filter by name. </p>
+    </div>
+    <p> A <a data-link-type="dfn" href="#bluetooth-device">Bluetooth device</a> <var>device</var> <dfn data-dfn-type="dfn" data-local-lt="match a filter|matches any filter" data-noexport="" id="matches-a-filter">matches a filter<a class="self-link" href="#matches-a-filter"></a></dfn> <var>filter</var> if the following steps return <code>match</code>: </p>
+    <ol>
+     <li> If <code><var>filter</var>.name</code> is present then,
+      if <var>device</var>’s <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> isn’t complete
+      and equal to <code><var>filter</var>.name</code>,
+      return <code>mismatch</code>. 
+     <li> If <code><var>filter</var>.namePrefix</code> is present then
+      let <var>deviceName</var> be <var>device</var>’s partial or complete <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a>,
+      or <code>""</code> if <var>device</var>’s <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> is absent.
+      If <code><var>deviceName</var>.<code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-string.prototype.startswith">startsWith</a></code>(<var>filter</var>.namePrefix)</code> is <code>false</code>,
+      return <code>mismatch</code>. 
+     <li> For each <var>uuid</var> in <code><var>filter</var>.services</code>,
+      if the UA has not received advertising data, an <a data-link-type="dfn" href="#extended-inquiry-response">extended inquiry response</a>,
+      or a service discovery response indicating that
+      the device supports a primary (vs included) service with UUID <var>uuid</var>,
+      return <code>mismatch</code>. 
+     <li>Return <code>match</code>. 
+    </ol>
     <p class="note" role="note"> The list of Service UUIDs that a device advertises
     might not include all the UUIDs the device supports.
     The advertising data does specify whether this list is complete.
@@ -1558,12 +1648,22 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
          For each <var>filter</var> in <code><var>options</var>.filters</code>,
           do the following steps: 
         <ol>
-         <li> If <code><var>filter</var>.services.length === 0</code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
-         <li> Let <var>services</var> be <code><code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-array.prototype.map">Array.prototype.map</a></code>.call(<var>filter</var>.services, <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService</a></code>)</code>. 
-         <li> If any of the <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService()</a></code> calls threw an exception, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with that exception and abort these steps. 
-         <li> If any <var>service</var> in <var>services</var> is <a data-link-type="dfn" href="#blacklisted">blacklisted</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps. 
-         <li>Append <code>{services: <var>services</var>}</code> to <var>uuidFilters</var>.
-         <li>Add the elements of <var>services</var> to <var>requiredServiceUUIDs</var>.
+         <li>Let <var>canonicalizedFilter</var> be <code>{}</code>.
+         <li>
+           If <code><var>filter</var>.services</code> is present, do the following sub-steps: 
+          <ol>
+           <li> If <code><var>filter</var>.services.length === 0</code>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
+           <li> Let <var>services</var> be <code><code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-array.prototype.map">Array.prototype.map</a></code>.call(<var>filter</var>.services, <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService</a></code>)</code>. 
+           <li> If any of the <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService()</a></code> calls threw an exception, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with that exception and abort these steps. 
+           <li> If any <var>service</var> in <var>services</var> is <a data-link-type="dfn" href="#blacklisted">blacklisted</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps. 
+           <li> Set <code><var>canonicalizedFilter</var>.services</code> to <var>services</var>. 
+           <li>Add the elements of <var>services</var> to <var>requiredServiceUUIDs</var>.
+          </ol>
+         <li> If <code><var>filter</var>.name</code> is present,
+              set <code><var>canonicalizedFilter</var>.name</code> to <code><var>filter</var>.name</code>. 
+         <li> If <code><var>filter</var>.namePrefix</code> is present,
+              set <code><var>canonicalizedFilter</var>.namePrefix</code> to <code><var>filter</var>.namePrefix</code>. 
+         <li>Append <var>canonicalizedFilter</var> to <var>uuidFilters</var>.
         </ol>
        <li> Let <var>optionalServiceUUIDs</var> be <code><code class="idl"><a data-link-type="idl" href="http://ecma-international.org/ecma-262/6.0/#sec-array.prototype.map">Array.prototype.map</a></code>.call(<var>options</var>.optionalServices, <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService</a></code>)</code>. 
        <li> If any of the <code class="idl"><a data-link-type="idl" href="#dom-bluetoothuuid-getservice">BluetoothUUID.getService()</a></code> calls threw an exception, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide#reject-promise">reject</a> <var>promise</var> with that exception and abort these steps. 
@@ -1677,7 +1777,9 @@ interface <dfn class="idl-code" data-dfn-type="interface" data-export="" id="blu
       <li>An optional 128-bit <a data-link-type="dfn" href="#identity-resolving-key">Identity Resolving Key</a>.
       <li> An optional partial or complete <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a>.
         A device has a partial name when the <a data-link-type="dfn" href="https://www.bluetooth.org/en-us/specification/assigned-numbers/generic-access-profile#">Shortened Local Name</a> AD data was received,
-        but the full name hasn’t been read yet. 
+        but the full name hasn’t been read yet.
+        When the <a data-link-type="dfn" href="#bluetooth-device-name">Bluetooth Device Name</a> is encoded as UTF-8 and
+        converted to a DOMString using the <a data-link-type="dfn" href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">utf-8 decode without BOM</a> algorithm. 
       <li> An <a data-link-type="dfn" href="#att-bearer">ATT Bearer</a>, over which all GATT communication happens.
         The <a data-link-type="dfn" href="#att-bearer">ATT Bearer</a> is created by procedures described in
         "Connection Establishment" under <a data-link-type="dfn" href="#gap-interoperability-requirements">GAP Interoperability Requirements</a>.
@@ -3420,15 +3522,18 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
    <li><a href="#manufacturer-specific-data">Manufacturer Specific Data</a><span>, in §9</span>
    <li><a href="#matches-a-filter">match a filter</a><span>, in §3</span>
    <li><a href="#matches-a-filter">matches a filter</a><span>, in §3</span>
+   <li><a href="#matches-a-filter">matches any filter</a><span>, in §3</span>
    <li>
     name
     <ul>
+     <li><a href="#dom-bluetoothscanfilter-name">dict-member for BluetoothScanFilter</a><span>, in §3</span>
      <li><a href="#dom-bluetoothdevice-name">attribute for BluetoothDevice</a><span>, in §4.3</span>
      <li><a href="#dom-bluetoothuuid-getservice-name-name">argument for BluetoothUUID/getService(name)</a><span>, in §6.1</span>
      <li><a href="#dom-bluetoothuuid-getcharacteristic-name-name">argument for BluetoothUUID/getCharacteristic(name)</a><span>, in §6.1</span>
      <li><a href="#dom-bluetoothuuid-getdescriptor-name-name">argument for BluetoothUUID/getDescriptor(name)</a><span>, in §6.1</span>
     </ul>
    <li><a href="#name-discovery-procedure">Name Discovery Procedure</a><span>, in §9</span>
+   <li><a href="#dom-bluetoothscanfilter-nameprefix">namePrefix</a><span>, in §3</span>
    <li><a href="#dom-bluetoothcharacteristicproperties-notify">notify</a><span>, in §5.4.1</span>
    <li><a href="#observation-procedure">Observation Procedure</a><span>, in §9</span>
    <li><a href="#observer">Observer</a><span>, in §9</span>
@@ -3575,6 +3680,7 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-map-constructor">Map</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-promise-objects">Promise</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-set-objects">Set</a>
+     <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-string.prototype.startswith">String.prototype.startsWith</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a>
      <li><a href="http://ecma-international.org/ecma-262/6.0/#sec-typedarray-constructors">TypedArray</a>
     </ul>
@@ -3598,6 +3704,11 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
      <li><a href="https://dom.spec.whatwg.org/#concept-tree-child">children</a>
      <li><a href="https://dom.spec.whatwg.org/#concept-event-fire">fire an event</a>
      <li><a href="http://dom.spec.whatwg.org/#concept-tree-participate">participate in a tree</a>
+    </ul>
+   <li>
+    <a data-link-type="biblio" href="#biblio-encoding">[encoding]</a> defines the following terms:
+    <ul>
+     <li><a href="https://encoding.spec.whatwg.org/#utf-8-decode-without-bom">utf-8 decode without bom</a>
     </ul>
    <li>
     <a data-link-type="biblio" href="#biblio-html">[HTML]</a> defines the following terms:
@@ -3653,6 +3764,8 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
    <dd>Cameron McCormack; Boris Zbarsky. <a href="http://www.w3.org/TR/WebIDL-1/">WebIDL Level 1</a>. 4 August 2015. WD. URL: <a href="http://www.w3.org/TR/WebIDL-1/">http://www.w3.org/TR/WebIDL-1/</a>
    <dt id="biblio-dom-ls"><a class="self-link" href="#biblio-dom-ls"></a>[DOM-LS]
    <dd>Document Object Model URL: <a href="https://dom.spec.whatwg.org/">https://dom.spec.whatwg.org/</a>
+   <dt id="biblio-encoding"><a class="self-link" href="#biblio-encoding"></a>[ENCODING]
+   <dd>Anne van Kesteren; Joshua Bell; Addison Phillips. <a href="http://www.w3.org/TR/encoding/">Encoding</a>. 16 September 2014. CR. URL: <a href="http://www.w3.org/TR/encoding/">http://www.w3.org/TR/encoding/</a>
    <dt id="biblio-powerful-features"><a class="self-link" href="#biblio-powerful-features"></a>[POWERFUL-FEATURES]
    <dd>Mike West; Yan Zhu. <a href="http://www.w3.org/TR/powerful-features/">Privileged Contexts</a>. 24 April 2015. WD. URL: <a href="http://www.w3.org/TR/powerful-features/">http://www.w3.org/TR/powerful-features/</a>
    <dt id="biblio-promises-guide"><a class="self-link" href="#biblio-promises-guide"></a>[PROMISES-GUIDE]
@@ -3665,6 +3778,8 @@ typedef (DOMString or unsigned long) <a class="idl-code" data-link-type="typedef
   <h2 class="no-num heading settled" id="idl-index"><span class="content">IDL Index</span><a class="self-link" href="#idl-index"></a></h2>
 <pre class="idl">dictionary <a href="#dictdef-bluetoothscanfilter">BluetoothScanFilter</a> {
   sequence&lt;<a data-link-type="idl-name" href="#typedefdef-bluetoothserviceuuid">BluetoothServiceUUID</a>> <a class="idl-code" data-link-type="dict-member" data-type="sequence<BluetoothServiceUUID> " href="#dom-bluetoothscanfilter-services">services</a>;
+  DOMString <a class="idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-bluetoothscanfilter-name">name</a>;
+  DOMString <a class="idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-bluetoothscanfilter-nameprefix">namePrefix</a>;
 };
 
 dictionary <a href="#dictdef-requestdeviceoptions">RequestDeviceOptions</a> {


### PR DESCRIPTION
Preview at https://rawgit.com/jyasskin/web-bluetooth-1/new-scan-filters/index.html#device-discovery.

I think I got all the places that assumed filters only had services, but please let me know if I missed any.