### PR TITLE
Remove extra closing paren from example code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -251,7 +251,7 @@ spec: webidl
               .then(handleBodySensorLocationCharacteristic),
             service.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()"
                        >getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.heart_rate_measurement"
-            >'heart_rate_measurement'</a>))
+            >'heart_rate_measurement'</a>)
               .then(handleHeartRateMeasurementCharacteristic),
           ]);
         });


### PR DESCRIPTION
Just a quick nit I discovered while experimenting with the APIs. This is awesome, thanks for your work on it!