### PR TITLE
Use the [SecureContext] IDL attribute to enforce secure contexts.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -111,7 +111,6 @@ spec: html
         text: event handler idl attribute
         text: global object
         text: in parallel
-        text: incumbent settings object
         text: perform a microtask checkpoint
         text: queue a task
         text: relevant settings object
@@ -348,7 +347,8 @@ spec: permissions
       To help ensure that only the entity the user approved for access actually has access,
       this specification requires that only <a>secure context</a>s
       can access Bluetooth devices
-      (<a href="#requestDevice-secure-context">requestDevice</a>).
+      (<a idl lt="Bluetooth">requestDevice</a>).
+    </p>
   </section>
 
   <section class="non-normative">
@@ -513,7 +513,7 @@ spec: permissions
 </section>
 
 <section>
-  <h2 id="device-discovery">Device Discovery</h2>
+  <h2 id="device-discovery" oldids="requestDevice-secure-context">Device Discovery</h2>
 
   <pre class="idl">
     dictionary BluetoothRequestDeviceFilter {
@@ -528,6 +528,7 @@ spec: permissions
     };
 
     interface Bluetooth {
+      [SecureContext]
       Promise&lt;BluetoothDevice> requestDevice(RequestDeviceOptions options);
     };
     Bluetooth implements EventTarget;
@@ -861,10 +862,6 @@ spec: permissions
     and run the following steps <a>in parallel</a>:
   </p>
   <ol class="algorithm">
-    <li id="requestDevice-secure-context">
-      If the <a>incumbent settings object</a> is not a <a>secure context</a>,
-      <a>reject</a> <var>promise</var> with a {{SecurityError}} and abort these steps.
-    </li>
     <li id="requestDevice-user-gesture">
       If the algorithm is not <a>triggered by user activation</a>,
       <a>reject</a> <var>promise</var> with a {{SecurityError}} and abort these steps.

--- a/index.html
+++ b/index.html
@@ -1707,7 +1707,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
      <p> To help ensure that only the entity the user approved for access actually has access,
       this specification requires that only <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>s
       can access Bluetooth devices
-      (<a href="#requestDevice-secure-context">requestDevice</a>). </p>
+      (<a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-1">requestDevice</a>). </p>
     </section>
     <section class="non-normative">
      <h3 class="heading settled" data-level="2.2" id="server-takeovers"><span class="secno">2.2. </span><span class="content">Trusted servers can serve malicious code</span><a class="self-link" href="#server-takeovers"></a></h3>
@@ -1819,7 +1819,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
     </section>
    </section>
    <section>
-    <h2 class="heading settled" data-level="3" id="device-discovery"><span class="secno">3. </span><span class="content">Device Discovery</span><a class="self-link" href="#device-discovery"></a></h2>
+    <h2 class="heading settled" data-level="3" id="device-discovery"><span class="secno">3. </span><span class="content">Device Discovery</span><span id="requestDevice-secure-context"></span><a class="self-link" href="#device-discovery"></a></h2>
 <pre class="idl highlight def"><span class="kt">dictionary</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="dictionary" data-export="" id="dictdef-bluetoothrequestdevicefilter">BluetoothRequestDeviceFilter</dfn> {
   <span class="kt">sequence</span>&lt;<a class="n" data-link-type="idl-name" href="#typedefdef-bluetoothserviceuuid" id="ref-for-typedefdef-bluetoothserviceuuid-1">BluetoothServiceUUID</a>> <a class="nv idl-code" data-link-type="dict-member" data-type="sequence<BluetoothServiceUUID> " href="#dom-bluetoothrequestdevicefilter-services" id="ref-for-dom-bluetoothrequestdevicefilter-services-1">services</a>;
   <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="dict-member" data-type="DOMString " href="#dom-bluetoothrequestdevicefilter-name" id="ref-for-dom-bluetoothrequestdevicefilter-name-1">name</a>;
@@ -1832,15 +1832,16 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
 };
 
 <span class="kt">interface</span> <dfn class="nv dfn-paneled idl-code" data-dfn-type="interface" data-export="" id="bluetooth">Bluetooth</dfn> {
+  [<a class="nv idl-code" data-link-type="extended-attribute">SecureContext</a>]
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#bluetoothdevice" id="ref-for-bluetoothdevice-1">BluetoothDevice</a>> <a class="nv idl-code" data-link-type="method" href="#dom-bluetooth-requestdevice" id="ref-for-dom-bluetooth-requestdevice-3">requestDevice</a>(<a class="n" data-link-type="idl-name" href="#dictdef-requestdeviceoptions" id="ref-for-dictdef-requestdeviceoptions-1">RequestDeviceOptions</a> <dfn class="nv idl-code" data-dfn-for="Bluetooth/requestDevice(options)" data-dfn-type="argument" data-export="" id="dom-bluetooth-requestdevice-options-options">options<a class="self-link" href="#dom-bluetooth-requestdevice-options-options"></a></dfn>);
 };
-<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-1">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>;
-<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-2">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#bluetoothdeviceeventhandlers" id="ref-for-bluetoothdeviceeventhandlers-1">BluetoothDeviceEventHandlers</a>;
-<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-3">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#characteristiceventhandlers" id="ref-for-characteristiceventhandlers-1">CharacteristicEventHandlers</a>;
-<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-4">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#serviceeventhandlers" id="ref-for-serviceeventhandlers-1">ServiceEventHandlers</a>;
+<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-2">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>;
+<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-3">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#bluetoothdeviceeventhandlers" id="ref-for-bluetoothdeviceeventhandlers-1">BluetoothDeviceEventHandlers</a>;
+<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-4">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#characteristiceventhandlers" id="ref-for-characteristiceventhandlers-1">CharacteristicEventHandlers</a>;
+<a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-5">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="#serviceeventhandlers" id="ref-for-serviceeventhandlers-1">ServiceEventHandlers</a>;
 </pre>
     <div class="note no-marker" role="note">
-     <div class="marker">NOTE: <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-5">Bluetooth</a></code> members</div>
+     <div class="marker">NOTE: <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-6">Bluetooth</a></code> members</div>
      <p> <code class="idl"><a data-link-type="idl" href="#dom-bluetooth-requestdevice" id="ref-for-dom-bluetooth-requestdevice-4">requestDevice(options)</a></code> asks the user
       to grant this origin access to a device
       that <a data-link-type="dfn" href="#matches-a-filter" id="ref-for-matches-a-filter-1">matches any filter</a> in <code>options.<dfn class="dfn-paneled idl-code" data-dfn-for="RequestDeviceOptions" data-dfn-type="dict-member" data-export="" id="dom-requestdeviceoptions-filters">filters</dfn></code>.
@@ -2018,7 +2019,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
         <td><code>namePrefix</code>, if present, must be non-empty to filter devices.
      </table>
     </div>
-    <p> Instances of <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-6">Bluetooth</a></code> are created with the internal slots
+    <p> Instances of <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-7">Bluetooth</a></code> are created with the internal slots
     described in the following table: </p>
     <table class="data">
      <thead>
@@ -2087,7 +2088,6 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
     and a <code class="idl"><a data-link-type="idl" href="#bluetoothpermissionresult" id="ref-for-bluetoothpermissionresult-1">BluetoothPermissionResult</a></code> <var>status</var>,
     the UA MUST return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-new-promise">a new promise</a> <var>promise</var> and run the following steps <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>: </p>
     <ol class="algorithm">
-     <li id="requestDevice-secure-context"><a class="self-link" href="#requestDevice-secure-context"></a> If the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a> is not a <a data-link-type="dfn" href="https://w3c.github.io/webappsec-secure-contexts/#secure-context">secure context</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps. 
      <li id="requestDevice-user-gesture"><a class="self-link" href="#requestDevice-user-gesture"></a> If the algorithm is not <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/interaction.html#triggered-by-user-activation">triggered by user activation</a>, <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#reject-promise">reject</a> <var>promise</var> with a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps. 
      <li>
        In order to convert the arguments from service names and aliases to just <a data-link-type="dfn" href="#uuid" id="ref-for-uuid-1">UUID</a>s,
@@ -2451,7 +2451,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
     </section>
     <section>
      <h3 class="heading settled dfn-paneled idl-code" data-dfn-type="interface" data-export="" data-level="4.3" data-lt="BluetoothDevice" id="bluetoothdevice"><span class="secno">4.3. </span><span class="content">BluetoothDevice</span></h3>
-     <p> A <code class="idl"><a data-link-type="idl" href="#bluetoothdevice" id="ref-for-bluetoothdevice-7">BluetoothDevice</a></code> instance represents a <a data-link-type="dfn" href="#bluetooth-device" id="ref-for-bluetooth-device-13">Bluetooth device</a> for a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (or, equivalently, for a particular <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> or <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-7">Bluetooth</a></code> instance). </p>
+     <p> A <code class="idl"><a data-link-type="idl" href="#bluetoothdevice" id="ref-for-bluetoothdevice-7">BluetoothDevice</a></code> instance represents a <a data-link-type="dfn" href="#bluetooth-device" id="ref-for-bluetooth-device-13">Bluetooth device</a> for a particular <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a> (or, equivalently, for a particular <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> or <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-8">Bluetooth</a></code> instance). </p>
 <pre class="idl highlight def"><span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="#bluetoothdevice" id="ref-for-bluetoothdevice-8">BluetoothDevice</a> {
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span> <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString" href="#dom-bluetoothdevice-id" id="ref-for-dom-bluetoothdevice-id-2">id</a>;
   <span class="kt">readonly</span> <span class="kt">attribute</span> <span class="kt">DOMString</span>? <a class="nv idl-code" data-link-type="attribute" data-readonly="" data-type="DOMString?" href="#dom-bluetoothdevice-name" id="ref-for-dom-bluetoothdevice-name-1">name</a>;
@@ -2495,7 +2495,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="BluetoothDevice" data-dfn-type="attribute" data-export="" id="dom-bluetoothdevice-context-slot">[[context]]</dfn>
         <td><code>undefined</code>
-        <td> The <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-8">Bluetooth</a></code> object that returned this <code class="idl"><a data-link-type="idl" href="#bluetoothdevice" id="ref-for-bluetoothdevice-15">BluetoothDevice</a></code>. 
+        <td> The <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-9">Bluetooth</a></code> object that returned this <code class="idl"><a data-link-type="idl" href="#bluetoothdevice" id="ref-for-bluetoothdevice-15">BluetoothDevice</a></code>. 
        <tr>
         <td><dfn class="dfn-paneled idl-code" data-dfn-for="BluetoothDevice" data-dfn-type="attribute" data-export="" id="dom-bluetoothdevice-representeddevice-slot">[[representedDevice]]</dfn>
         <td><code>undefined</code>
@@ -2523,7 +2523,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
         <td> Cached value of <code class="idl"><a data-link-type="idl" href="#dom-bluetoothdevice-uuids" id="ref-for-dom-bluetoothdevice-uuids-3">uuids</a></code>.
           Up to date if <code class="idl"><a data-link-type="idl" href="#dom-bluetoothdevice-cachedallowedservices-slot" id="ref-for-dom-bluetoothdevice-cachedallowedservices-slot-1">[[cachedAllowedServices]]</a></code> is equal to <code class="idl"><a data-link-type="idl" href="#dom-bluetoothdevice-allowedservices-slot" id="ref-for-dom-bluetoothdevice-allowedservices-slot-3">[[allowedServices]]</a></code>. 
      </table>
-     <p> To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="get-the-bluetoothdevice-representing">get the <code>BluetoothDevice</code> representing</dfn> a <a data-link-type="dfn" href="#bluetooth-device" id="ref-for-bluetooth-device-15">Bluetooth device</a> <var>device</var> inside a <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-9">Bluetooth</a></code> instance <var>context</var>,
+     <p> To <dfn class="dfn-paneled" data-dfn-type="dfn" data-export="" id="get-the-bluetoothdevice-representing">get the <code>BluetoothDevice</code> representing</dfn> a <a data-link-type="dfn" href="#bluetooth-device" id="ref-for-bluetooth-device-15">Bluetooth device</a> <var>device</var> inside a <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-10">Bluetooth</a></code> instance <var>context</var>,
       and an optional <code class="idl"><a data-link-type="idl" href="#dictdef-bluetoothpermissionstorage" id="ref-for-dictdef-bluetoothpermissionstorage-6">BluetoothPermissionStorage</a></code> <var>storage</var>,
       the UA MUST run the following steps: </p>
      <ol class="algorithm">
@@ -2881,7 +2881,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
         The cache MUST NOT contain two entities that are for the <a data-link-type="dfn" href="#same-attribute" id="ref-for-same-attribute-1">same attribute</a>.
         Each known-present entity in the cache is associated with an optional <code>Promise&lt;<code class="idl"><a data-link-type="idl" href="#bluetoothremotegattservice" id="ref-for-bluetoothremotegattservice-3">BluetoothRemoteGATTService</a></code>></code>, <code>Promise&lt;<code class="idl"><a data-link-type="idl" href="#bluetoothremotegattcharacteristic" id="ref-for-bluetoothremotegattcharacteristic-4">BluetoothRemoteGATTCharacteristic</a></code>></code>,
         or <code>Promise&lt;<code class="idl"><a data-link-type="idl" href="#bluetoothremotegattdescriptor" id="ref-for-bluetoothremotegattdescriptor-3">BluetoothRemoteGATTDescriptor</a></code>></code> instance
-        for each <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-10">Bluetooth</a></code> instance. </p>
+        for each <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-11">Bluetooth</a></code> instance. </p>
       <p class="note" role="note"> For example, if a user calls the <code>serviceA.getCharacteristic(uuid1)</code> function
         with an initially empty <a data-link-type="dfn" href="#bluetooth-cache" id="ref-for-bluetooth-cache-5">Bluetooth cache</a>,
         the UA uses the <a data-link-type="dfn" href="#discover-characteristics-by-uuid" id="ref-for-discover-characteristics-by-uuid-1">Discover Characteristics by UUID</a> procedure
@@ -3297,7 +3297,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
        </ol>
      </ol>
      <p> The UA MUST maintain a map from each known GATT <a data-link-type="dfn" href="#characteristic" id="ref-for-characteristic-10">Characteristic</a> to
-      a set of <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-11">Bluetooth</a></code> objects known as
+      a set of <code class="idl"><a data-link-type="idl" href="#bluetooth" id="ref-for-bluetooth-12">Bluetooth</a></code> objects known as
       the characteristic’s <dfn class="dfn-paneled" data-dfn-type="dfn" data-noexport="" id="active-notification-context-set">active notification context set</dfn>. <span class="note" role="note"> The set for a given characteristic holds
         the <code class="idl"><a data-link-type="idl" href="#dom-navigator-bluetooth" id="ref-for-dom-navigator-bluetooth-1">navigator.bluetooth</a></code> objects for
         each <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#sec-code-realms">Realm</a> that has registered for notifications. </span> </p>
@@ -3871,7 +3871,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
    <section>
     <h2 class="heading settled" data-level="8" id="navigator-extensions"><span class="secno">8. </span><span class="content">Extensions to the Navigator Interface</span><a class="self-link" href="#navigator-extensions"></a></h2>
 <pre class="idl highlight def"><span class="kt">partial</span> <span class="kt">interface</span> <a class="nv idl-code" data-link-type="interface" href="https://html.spec.whatwg.org/multipage/webappapis.html#navigator">Navigator</a> {
-  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-12">Bluetooth</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Bluetooth" id="dom-navigator-bluetooth">bluetooth</dfn>;
+  <span class="kt">readonly</span> <span class="kt">attribute</span> <a class="n" data-link-type="idl-name" href="#bluetooth" id="ref-for-bluetooth-13">Bluetooth</a> <dfn class="nv dfn-paneled idl-code" data-dfn-for="Navigator" data-dfn-type="attribute" data-export="" data-readonly="" data-type="Bluetooth" id="dom-navigator-bluetooth">bluetooth</dfn>;
 };
 </pre>
    </section>
@@ -4781,7 +4781,6 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-idl-attributes">event handler idl attribute</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#global-object">global object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in parallel</a>
-     <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#incumbent-settings-object">incumbent settings object</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#perform-a-microtask-checkpoint">perform a microtask checkpoint</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a task</a>
      <li><a href="https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant settings object</a>
@@ -4897,6 +4896,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
 };
 
 <span class="kt">interface</span> <a class="nv" href="#bluetooth">Bluetooth</a> {
+  [<a class="nv idl-code" data-link-type="extended-attribute">SecureContext</a>]
   <span class="kt">Promise</span>&lt;<a class="n" data-link-type="idl-name" href="#bluetoothdevice">BluetoothDevice</a>> <a class="nv idl-code" data-link-type="method" href="#dom-bluetooth-requestdevice">requestDevice</a>(<a class="n" data-link-type="idl-name" href="#dictdef-requestdeviceoptions">RequestDeviceOptions</a> <a class="nv" href="#dom-bluetooth-requestdevice-options-options">options</a>);
 };
 <a class="n" data-link-type="idl-name" href="#bluetooth">Bluetooth</a> <span class="kt">implements</span> <a class="n" data-link-type="idl-name" href="https://dom.spec.whatwg.org/#eventtarget">EventTarget</a>;
@@ -5099,11 +5099,12 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
   <aside class="dfn-panel" data-for="bluetooth">
    <b><a href="#bluetooth">#bluetooth</a></b><b>Referenced in:</b>
    <ul>
-    <li><a href="#ref-for-bluetooth-1">3. Device Discovery</a> <a href="#ref-for-bluetooth-2">(2)</a> <a href="#ref-for-bluetooth-3">(3)</a> <a href="#ref-for-bluetooth-4">(4)</a> <a href="#ref-for-bluetooth-5">(5)</a> <a href="#ref-for-bluetooth-6">(6)</a>
-    <li><a href="#ref-for-bluetooth-7">4.3. BluetoothDevice</a> <a href="#ref-for-bluetooth-8">(2)</a> <a href="#ref-for-bluetooth-9">(3)</a>
-    <li><a href="#ref-for-bluetooth-10">5.1.1. The Bluetooth cache</a>
-    <li><a href="#ref-for-bluetooth-11">5.4. BluetoothRemoteGATTCharacteristic</a>
-    <li><a href="#ref-for-bluetooth-12">8. Extensions to the Navigator Interface</a>
+    <li><a href="#ref-for-bluetooth-1">2.1. Device access is powerful</a>
+    <li><a href="#ref-for-bluetooth-2">3. Device Discovery</a> <a href="#ref-for-bluetooth-3">(2)</a> <a href="#ref-for-bluetooth-4">(3)</a> <a href="#ref-for-bluetooth-5">(4)</a> <a href="#ref-for-bluetooth-6">(5)</a> <a href="#ref-for-bluetooth-7">(6)</a>
+    <li><a href="#ref-for-bluetooth-8">4.3. BluetoothDevice</a> <a href="#ref-for-bluetooth-9">(2)</a> <a href="#ref-for-bluetooth-10">(3)</a>
+    <li><a href="#ref-for-bluetooth-11">5.1.1. The Bluetooth cache</a>
+    <li><a href="#ref-for-bluetooth-12">5.4. BluetoothRemoteGATTCharacteristic</a>
+    <li><a href="#ref-for-bluetooth-13">8. Extensions to the Navigator Interface</a>
    </ul>
   </aside>
   <aside class="dfn-panel" data-for="dom-requestdeviceoptions-filters">


### PR DESCRIPTION
Instead of manually throwing an exception from requestDevice().

@mikewest, is [`[SecureContext]`](https://heycam.github.io/webidl/#SecureContext) ready to use here? Do you recommend putting it on just the entry function, or on all the interfaces? (It's also not implemented in Chrome yet, but I assume that's just a matter of time.)

Preview at https://rawgit.com/jyasskin/web-bluetooth-1/secure-context-attribute/index.html#device-discovery