### PR TITLE
Fix a typo in the characteristic's ReadValue function (Step 2)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3215,7 +3215,7 @@ function interpretIBeacon(event) {
      <ol class="algorithm">
       <li> If <code>this.uuid</code> is <a data-link-type="dfn" href="#blacklisted-for-reads" id="ref-for-blacklisted-for-reads-1">blacklisted for reads</a>,
         return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps. 
-      <li> If <code>this.characteristic.service.device.gatt.<code class="idl"><a data-link-type="idl" href="#dom-bluetoothremotegattserver-connected" id="ref-for-dom-bluetoothremotegattserver-connected-8">connected</a></code></code> is <code>false</code>,
+      <li> If <code>this.service.device.gatt.<code class="idl"><a data-link-type="idl" href="#dom-bluetoothremotegattserver-connected" id="ref-for-dom-bluetoothremotegattserver-connected-8">connected</a></code></code> is <code>false</code>,
         return <a data-link-type="dfn" href="https://www.w3.org/2001/tag/doc/promises-guide/#a-promise-rejected-with">a promise rejected with</a> a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#networkerror">NetworkError</a></code> and abort these steps. 
       <li> Let <var>characteristic</var> be the <a data-link-type="dfn" href="#characteristic" id="ref-for-characteristic-8">Characteristic</a> that <code>this</code> represents. 
       <li>


### PR DESCRIPTION
Hi I'm working at the University of Szeged in the team working on Web Bluetooth in servo. I found a typo in function https://webbluetoothcg.github.io/web-bluetooth/#dom-bluetoothremotegattcharacteristic-readvalue (Step 2). In `this.characteristic.service.device.gatt` the characteristic does not have a `characteristic` field just a `service`. So in this case `this.service.device.gatt` should be the correct phrasing.