### PR TITLE
s/substeps/sub-steps/g

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -922,7 +922,7 @@ spec: permissions
     </li>
     <li>
       In order to convert the arguments from service names and aliases to just <a>UUID</a>s,
-      do the following substeps:
+      do the following sub-steps:
       <ol>
         <li>
           If <code>|filters|.length === 0</code>,
@@ -1151,7 +1151,7 @@ spec: permissions
     <li>Let <var>result</var> be a set of <a>Bluetooth device</a>s, initially empty.</li>
     <li>
       For each <a>Bluetooth device</a> <var>device</var> in <var>nearbyDevices</var>,
-      do the following substeps:
+      do the following sub-steps:
       <ol>
         <li>
           If <var>device</var>'s <a>supported physical transports</a> include LE and
@@ -1162,7 +1162,7 @@ spec: permissions
         <li>
           If <var>device</var>'s advertised <a>Service UUIDs</a>
           have a non-empty intersection with the <var>set of <a>Service</a> UUIDs</var>,
-          add <var>device</var> to <var>result</var> and abort these substeps.
+          add <var>device</var> to <var>result</var> and abort these sub-steps.
 
           <p class="note">
             For BR/EDR devices, there is no way to distinguish GATT from non-GATT services
@@ -1402,7 +1402,7 @@ spec: permissions
           </li>
           <li>
             For each |allowedDevice| in <code>|data|.allowedDevices</code>,
-            run the following substeps:
+            run the following sub-steps:
             <ol>
               <li>
                 If <code><var>desc</var>.deviceId</code> is set
@@ -1449,7 +1449,7 @@ spec: permissions
           </li>
           <li>
             For each {{BluetoothDevice}} instance |deviceObj| in the <a>current realm</a>,
-            run the following substeps:
+            run the following sub-steps:
             <ol>
               <li>
                 If there is an {{AllowedBluetoothDevice}} |allowedDevice| in <code>|data|.{{allowedDevices}}</code>

--- a/index.html
+++ b/index.html
@@ -2113,7 +2113,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
       throw a <code class="idl"><a data-link-type="idl" href="https://heycam.github.io/webidl/#securityerror">SecurityError</a></code> and abort these steps. 
      <li>
        In order to convert the arguments from service names and aliases to just <a data-link-type="dfn" href="#uuid" id="ref-for-uuid-1">UUID</a>s,
-      do the following substeps: 
+      do the following sub-steps: 
       <ol>
        <li> If <code><var>filters</var>.length === 0</code>,
           throw a <code class="idl"><a data-link-type="idl" href="https://tc39.github.io/ecma262/#sec-native-error-types-used-in-this-standard-typeerror">TypeError</a></code> and abort these steps. 
@@ -2231,14 +2231,14 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
      <li>Let <var>result</var> be a set of <a data-link-type="dfn" href="#bluetooth-device" id="ref-for-bluetooth-device-8">Bluetooth device</a>s, initially empty.
      <li>
        For each <a data-link-type="dfn" href="#bluetooth-device" id="ref-for-bluetooth-device-9">Bluetooth device</a> <var>device</var> in <var>nearbyDevices</var>,
-      do the following substeps: 
+      do the following sub-steps: 
       <ol>
        <li> If <var>device</var>’s <a data-link-type="dfn" href="#supported-physical-transports" id="ref-for-supported-physical-transports-1">supported physical transports</a> include LE and
           its <a data-link-type="dfn" href="#bluetooth-device-name" id="ref-for-bluetooth-device-name-6">Bluetooth Device Name</a> is partial or absent,
           the UA SHOULD perform the <a data-link-type="dfn" href="#name-discovery-procedure" id="ref-for-name-discovery-procedure-1">Name Discovery Procedure</a> to acquire a complete name. 
        <li>
          If <var>device</var>’s advertised <a data-link-type="dfn" href="#service-uuid-data-type" id="ref-for-service-uuid-data-type-1">Service UUIDs</a> have a non-empty intersection with the <var>set of <a data-link-type="dfn" href="#service" id="ref-for-service-4">Service</a> UUIDs</var>,
-          add <var>device</var> to <var>result</var> and abort these substeps. 
+          add <var>device</var> to <var>result</var> and abort these sub-steps. 
         <p class="note" role="note"> For BR/EDR devices, there is no way to distinguish GATT from non-GATT services
             in the <a data-link-type="dfn" href="#extended-inquiry-response" id="ref-for-extended-inquiry-response-2">Extended Inquiry Response</a>.
             If a site filters to the UUID of a non-GATT service,
@@ -2388,7 +2388,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
             be <code class="idl"><a data-link-type="idl" href="#dom-permissionname-bluetooth" id="ref-for-dom-permissionname-bluetooth-4">"bluetooth"</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#extra-permission-data">extra permission data</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>. 
         <li>
           For each <var>allowedDevice</var> in <code><var>data</var>.allowedDevices</code>,
-            run the following substeps: 
+            run the following sub-steps: 
          <ol>
           <li> If <code><var>desc</var>.deviceId</code> is set
                 and <code><var>allowedDevice</var>.deviceId != <var>desc</var>.deviceId</code>,
@@ -2412,7 +2412,7 @@ over the Bluetooth 4 wireless standard using the Generic Attribute Profile (GATT
             be <code class="idl"><a data-link-type="idl" href="#dom-permissionname-bluetooth" id="ref-for-dom-permissionname-bluetooth-5">"bluetooth"</a></code>'s <a data-link-type="dfn" href="https://w3c.github.io/permissions/#extra-permission-data">extra permission data</a> for the <a data-link-type="dfn" href="https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">current settings object</a>. 
         <li>
           For each <code class="idl"><a data-link-type="idl" href="#bluetoothdevice" id="ref-for-bluetoothdevice-10">BluetoothDevice</a></code> instance <var>deviceObj</var> in the <a data-link-type="dfn" href="https://tc39.github.io/ecma262/#current-realm">current realm</a>,
-            run the following substeps: 
+            run the following sub-steps: 
          <ol>
           <li>
             If there is an <code class="idl"><a data-link-type="idl" href="#dictdef-allowedbluetoothdevice" id="ref-for-dictdef-allowedbluetoothdevice-3">AllowedBluetoothDevice</a></code> <var>allowedDevice</var> in <code><var>data</var>.<code class="idl"><a data-link-type="idl" href="#dom-bluetoothpermissiondata-alloweddevices" id="ref-for-dom-bluetoothpermissiondata-alloweddevices-3">allowedDevices</a></code></code> such that: 


### PR DESCRIPTION
I found two expressions, "substeps" and "sub-steps".
How about unify them? If there is no reason to distinct.
There are more "sub-steps" in the document, so I changed "substeps" to "sub-steps".

-

I've read CONTRIBUTING.md and I've already joined to [the Community Group](https://www.w3.org/community/web-bluetooth/) as "Takuya Beppu".