### PR TITLE
Don't return blacklisted attributes from GetGATTChildren().

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2483,6 +2483,7 @@ spec: permissions
           <ul>
             <li>are within the Bluetooth entity represented by <var>attribute</var>,</li>
             <li>have a type described by <var>child type</var>,</li>
+            <li>have a UUID that is not <a>blacklisted</a>,</li>
             <li>if <var>uuid</var> is present, have a UUID of <var>uuid</var>,</li>
             <li>
               if <var>allowedUuids</var> is present and not `"all"`,


### PR DESCRIPTION
Preview at https://api.csswg.org/bikeshed/?url=https://github.com/jyasskin/web-bluetooth-1/raw/block-blacklisted-gatt-children/index.bs#getgattchildren

Fixes #216.