### PR TITLE
Make startNotifications() return the characteristic, and …

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -25,6 +25,7 @@ GATT Server Disconnect    | ✓         | ✓       | ✓   | ✓     |         
 Get Characteristics List  | ✓         | ✓       | 53  | ✓     |         |
 Device Disconnected Event | ✓         | ✓       | ✓   | ✓     |         |
 Get Primary Services List | 53        | 53      | 53  | 53    |         |
+startNotifications returns `this` |   |         |     |       |         |
 
 Tip: Chrome channel releases are tracked at [https://googlechrome.github.io/current-versions/](https://googlechrome.github.io/current-versions/).
 
@@ -50,7 +51,7 @@ https://szeged.github.io/servo/
 # Firefox
 - https://bugzilla.mozilla.org/show_bug.cgi?id=1204396
 - https://bugzilla.mozilla.org/buglist.cgi?quicksearch=%5Bweb-bluetooth%5D
- 
+
 # Microsoft Edge
 https://dev.windows.com/en-us/microsoft-edge/platform/status/webbluetooth
 

--- a/index.bs
+++ b/index.bs
@@ -228,8 +228,11 @@ spec: permissions
         }
 
         function handleHeartRateMeasurementCharacteristic(characteristic) {
-          characteristic.addEventListener('<a event>characteristicvaluechanged</a>', onHeartRateChanged);
-          return characteristic.<a for="BluetoothRemoteGATTCharacteristic">startNotifications()</a>;
+          return characteristic.<a for="BluetoothRemoteGATTCharacteristic">startNotifications()</a>
+          .then(_ => {
+            characteristic.addEventListener('<a event>characteristicvaluechanged</a>',
+                                            onHeartRateChanged);
+          });
         }
 
         function onHeartRateChanged(event) {
@@ -2948,7 +2951,7 @@ spec: permissions
           getDescriptors(optional BluetoothDescriptorUUID descriptor);
         Promise&lt;DataView> readValue();
         Promise&lt;void> writeValue(BufferSource value);
-        Promise&lt;void> startNotifications();
+        Promise&lt;BluetoothRemoteGATTCharacteristic> startNotifications();
         Promise&lt;void> stopNotifications();
       };
       BluetoothRemoteGATTCharacteristic implements EventTarget;
@@ -3215,7 +3218,7 @@ spec: permissions
       <li>
         If <var>characteristic</var>'s <a>active notification context set</a> contains
         {{Navigator/bluetooth|navigator.bluetooth}},
-        <a>resolve</a> <var>promise</var> with <code>undefined</code> and abort these steps.
+        <a>resolve</a> <var>promise</var> with `this` and abort these steps.
       </li>
       <li>
         If <code>this.service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code> is `false`,
@@ -3242,7 +3245,7 @@ spec: permissions
         to <var>characteristic</var>'s <a>active notification context set</a>.
       </li>
       <li>
-        <a>Resolve</a> <var>promise</var> with <code>undefined</code>.
+        <a>Resolve</a> <var>promise</var> with `this`.
       </li>
     </ol>
 

--- a/index.bs
+++ b/index.bs
@@ -2952,7 +2952,7 @@ spec: permissions
         Promise&lt;DataView> readValue();
         Promise&lt;void> writeValue(BufferSource value);
         Promise&lt;BluetoothRemoteGATTCharacteristic> startNotifications();
-        Promise&lt;void> stopNotifications();
+        Promise&lt;BluetoothRemoteGATTCharacteristic> stopNotifications();
       };
       BluetoothRemoteGATTCharacteristic implements EventTarget;
       BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;
@@ -3280,7 +3280,7 @@ spec: permissions
         <var>characteristic</var>'s <a>Client Characteristic Configuration</a> descriptor.
       </li>
       <li>
-        <a>Queue a task</a> to <a>resolve</a> <var>promise</var> with <code>undefined</code>.
+        <a>Queue a task</a> to <a>resolve</a> <var>promise</var> with `this`.
       </li>
     </ol>
 


### PR DESCRIPTION
make the example listen to the event after notifications start.

Fixes #176.

Preview at https://api.csswg.org/bikeshed/?url=https://github.com/jyasskin/web-bluetooth-1/raw/listen-event-after-start-notifications/index.bs#example-heart-rate-monitor