### PR TITLE
Allow requestDevice() to include non-discoverable devices.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1126,7 +1126,8 @@ spec: permissions
     </li>
     <li>Let <var>nearbyDevices</var> be a set of <a>Bluetooth device</a>s, initially empty.</li>
     <li>
-      If the UA supports the LE transport, perform the <a>General Discovery Procedure</a>
+      If the UA supports the LE transport, perform the <a>General Discovery Procedure</a>,
+      except that the UA may include devices that have no <a>Discoverable Mode</a> flag set,
       and add the discovered <a>Bluetooth device</a>s to <var>nearbyDevices</var>.
       The UA SHOULD enable the <a>Privacy Feature</a>.
 
@@ -4662,7 +4663,8 @@ spec: permissions
               <ol>
                 <li value="1"><dfn local-lt="Service UUIDs">Service UUID Data Type</dfn></li>
                 <li value="2"><dfn>Local Name Data Type</dfn></li>
-                <li value="3"><dfn>Flags Data Type</dfn></li>
+                <li value="3"><dfn>Flags Data Type</dfn>
+                  (defines the <dfn>Discoverable Mode</dfn> flags)</li>
                 <li value="4"><dfn>Manufacturer Specific Data</dfn></li>
                 <li value="5"><dfn>TX Power Level</dfn></li>
                 <li value="11"><dfn>Service Data</dfn></li>


### PR DESCRIPTION
The CoreBluetooth API doesn't allow the UA to check the discoverable flags, so
we can't require it in the spec.

Fixes #141.

Preview at https://api.csswg.org/bikeshed/?url=https://github.com/jyasskin/web-bluetooth-1/raw/discover-non-discoverable/index.bs#scan-for-devices