### PR TITLE
Fix nit in example code

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1273,7 +1273,7 @@ spec: permissions
           name: "bluetooth",
           deviceId: sessionStorage.lastDevice,
         }).then(result => {
-          if (result.<a idl for="BluetoothPermissionResult">devices</a>.length > 1) {
+          if (result.<a idl for="BluetoothPermissionResult">devices</a>.length == 1) {
             return result.devices[0];
           } else {
             throw new <a idl>DOMException</a>("Lost permission", "NotFoundError");


### PR DESCRIPTION
I believe `sessionStorage.lastDevice` is unique, therefore it makes more sense to check for `length == 1`. If not, it should be at least `length >= 1` not `length > 1`.

Preview at https://api.csswg.org/bikeshed/?url=https://github.com/WebBluetoothCG/web-bluetooth/raw/beaufortfrancois-patch-1/index.bs#example-permission-api-query

R=@jyasskin