### PR TITLE
Mark internal slots that the spec always initializes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1655,14 +1655,14 @@ spec: permissions
       </thead>
       <tr>
         <td><dfn>\[[context]]</dfn></td>
-        <td>`undefined`</td>
+        <td>&lt;always set in prose></td>
         <td>
           The {{Bluetooth}} object that returned this {{BluetoothDevice}}.
         </td>
       </tr>
       <tr>
         <td><dfn>\[[representedDevice]]</dfn></td>
-        <td>`undefined`</td>
+        <td>&lt;always set in prose></td>
         <td>
           The <a>Bluetooth device</a> this object represents.
         </td>
@@ -1680,7 +1680,7 @@ spec: permissions
       </tr>
       <tr>
         <td><dfn>\[[allowedServices]]</dfn></td>
-        <td>`undefined`</td>
+        <td>&lt;always set in prose></td>
         <td>
           This device's {{AllowedBluetoothDevice/allowedServices}} list for this origin
           or `"all"` if all services are allowed.


### PR DESCRIPTION
Marking them instead of saying their initial value is `undefined`, makes
it easier to see if I accidentally introduce an uninitialized path.

Preview at https://api.csswg.org/bikeshed/?url=https://github.com/jyasskin/web-bluetooth-1/raw/mark-always-initialized-fields/index.bs#dom-bluetoothdevice-context-slot