### PR TITLE
BluetoothDevice.gatt is not optional

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1697,7 +1697,7 @@ spec: html
       interface BluetoothDevice {
         readonly attribute DOMString id;
         readonly attribute DOMString? name;
-        readonly attribute BluetoothRemoteGATTServer? gatt;
+        readonly attribute BluetoothRemoteGATTServer gatt;
         readonly attribute FrozenArray&lt;UUID> uuids;
 
         Promise&lt;void> watchAdvertisements();


### PR DESCRIPTION
See https://chromium.googlesource.com/chromium/src/+/master/third_party/WebKit/Source/modules/bluetooth/BluetoothDevice.idl

Live preview at https://api.csswg.org/bikeshed/?url=https://github.com/WebBluetoothCG/web-bluetooth/raw/beaufortfrancois-patch-1/index.bs#bluetoothdevice

R: @jyasskin 