### PR TITLE
Expose whether Bluetooth is available.

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -13,6 +13,7 @@ Work is in progress:
 
 Feature/Platform          | Chrome OS | Android | Mac | Linux | Windows | iOS
 ------------------------- | :-------: | :-----: | :-: | :---: | :-----: | :-:
+getAvailability()         |           |         |     |       |         |
 Discovery                 | ✓         | ✓       | ✓   | ✓     | ✓       | See notes
 └ Name or prefix          | ✓         | ✓       | ✓   | ✓     | ✓       |
 └ Manufacturer/Service data |         |         |     |       |         |

--- a/index.bs
+++ b/index.bs
@@ -533,6 +533,10 @@ spec: html
 
     interface Bluetooth {
       [SecureContext]
+      Promise&lt;boolean> getAvailability();
+      [SecureContext]
+      attribute EventHandler onavailabilitychanged;
+      [SecureContext]
       readonly attribute BluetoothDevice? referringDevice;
       [SecureContext]
       Promise&lt;BluetoothDevice> requestDevice(optional RequestDeviceOptions options);
@@ -543,6 +547,14 @@ spec: html
     Bluetooth implements ServiceEventHandlers;
   </pre>
   <div class="note" heading="{{Bluetooth}} members">
+    <p>
+      {{Bluetooth/getAvailability()}} informs the page
+      whether Bluetooth is available at all.
+      An adapter that's disabled through software should count as available.
+      Changes in availability,
+      for example when the user physically attaches or detaches an adapter,
+      are reported through the {{availabilitychanged}} event.
+    </p>
     <p>
       {{Bluetooth/referringDevice}} gives access to
       the device from which the user opened this page, if any.
@@ -1696,6 +1708,96 @@ spec: html
         </ol>
       </dd>
     </dl>
+  </section>
+
+  <section>
+    <h3 id="availability">Overall Bluetooth availability</h3>
+
+    <p>
+      The UA may be running on a computer that has no Bluetooth radio.
+      {{requestDevice()}} handles this by failing to discover any devices,
+      which results in a {{NotFoundError}},
+      but websites may be able to handle it more gracefully.
+    </p>
+
+    <div class="example" id="example-getavailability">
+      <p>
+        To show Bluetooth UI only to users who have a Bluetooth adapter:
+      </p>
+      <pre highlight="js">
+      let bluetoothUI = document.querySelector('#bluetoothUI');
+      navigator.bluetooth.<a idl>getAvailability()</a>.then(available => {
+        bluetoothUI.hidden = !available;
+      });
+      navigator.bluetooth.addEventListener('<a idl>availabilitychanged</a>', e => {
+        bluetoothUI.hidden = !e.value;
+      });
+      </pre>
+    </div>
+
+    <div algorithm>
+      <p>
+        The <code><dfn method for="Bluetooth">getAvailability()</dfn></code> method,
+        when invoked, MUST return <a>a new promise</a> |promise|
+        and run the following steps <a>in parallel</a>:
+      </p>
+      <ol>
+        <li>
+          If the UA has the ability to use Bluetooth,
+          <a>queue a task</a> to <a>resolve</a> |promise| with `true`.
+        </li>
+        <li>
+          Otherwise, <a>queue a task</a> to <a>resolve</a> |promise| with `false`.
+        </li>
+      </ol>
+
+      Note: the promise is resolved <a>in parallel</a>
+      to let the UA call out to other systems
+      to determine whether Bluetooth is available.
+    </div>
+
+    <div algorithm="availabilitychanged">
+      <p>
+        If the UA becomes able or disable to use Bluetooth,
+        for example because a radio was physically attached or detached,
+        the UA must run the following steps:
+      </p>
+      <ol>
+        <li>
+          Let |available| be `true` if the UA is newly able to use Bluetooth,
+          or `false` otherwise.
+        </li>
+        <li>
+          For each <a>global object</a> |global|,
+          <a>queue a task</a> on its <a>responsible event loop</a> to
+          <a>fire an event</a> named {{availabilitychanged}}
+          using the {{ValueEvent}} interface
+          at <code>|global|.navigator.bluetooth</code>
+          with its {{ValueEvent/value}} attribute initialized to |available|.
+        </li>
+      </ol>
+    </div>
+
+    <pre class="idl">
+      [Constructor(DOMString type, optional ValueEventInit initDict)]
+      interface ValueEvent : Event {
+        readonly attribute any value;
+      };
+
+      dictionary ValueEventInit : EventInit {
+        any value = null;
+      };
+    </pre>
+
+    <p>
+      {{ValueEvent}} instances are constructed
+      as specified in [[DOM#constructing-events]].
+    </p>
+
+    <p>
+      The <dfn attribute for="ValueEvent">value</dfn> attribute
+      must return the value it was initialized to.
+    </p>
   </section>
 </section>
 
@@ -4027,6 +4129,13 @@ spec: html
           Fired on a {{BluetoothDevice}}
           when an <a href="#advertising-event-algorithm">advertising event
           is received from that device</a>.
+        </dd>
+
+        <dt><dfn event for="Bluetooth"><code>availabilitychanged</code></dfn></dt>
+        <dd>
+          Fired on {{Bluetooth|navigator.bluetooth}}
+          when the Bluetooth system as a whole
+          becomes available or unavailable to the UA.
         </dd>
 
         <dt><dfn event for="BluetoothRemoteGATTCharacteristic"><code>characteristicvaluechanged</code></dfn></dt>

--- a/index.bs
+++ b/index.bs
@@ -96,6 +96,10 @@ spec: ECMAScript; urlPrefix: https://tc39.github.io/ecma262/#
         text: TypeError; url: sec-native-error-types-used-in-this-standard-typeerror
         text: TypedArray; url: sec-typedarray-constructors
 
+spec: fingerprinting-guidance; urlPrefix: https://w3c.github.io/fingerprinting-guidance/#
+    type: dfn
+        text: fingerprinting surface; url: dfn-fingerprinting-surface
+
 spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
     type: dfn
         text: a copy of the bytes held; url: dfn-get-buffer-source-copy
@@ -1747,8 +1751,8 @@ spec: html
       </p>
       <pre highlight="js">
       let bluetoothUI = document.querySelector('#bluetoothUI');
-      navigator.bluetooth.<a idl>getAvailability()</a>.then(available => {
-        bluetoothUI.hidden = !available;
+      navigator.bluetooth.<a idl>getAvailability()</a>.then(isAvailable => {
+        bluetoothUI.hidden = !isAvailable;
       });
       navigator.bluetooth.addEventListener('<a idl>availabilitychanged</a>', e => {
         bluetoothUI.hidden = !e.value;
@@ -1763,6 +1767,12 @@ spec: html
         and run the following steps <a>in parallel</a>:
       </p>
       <ol>
+        <li id="override-availability">
+          If the user has configured the UA to
+          return a particular answer from this function for the current origin,
+          <a>queue a task</a> to <a>resolve</a> |promise| with the configured answer,
+          and abort these steps.
+        </li>
         <li>
           If the UA has the ability to use Bluetooth,
           <a>queue a task</a> to <a>resolve</a> |promise| with `true`.
@@ -1781,20 +1791,28 @@ spec: html
       <p>
         If the UA becomes able or unable to use Bluetooth,
         for example because a radio was physically attached or detached,
-        the UA must run the following steps:
+        or the user has changed
+        their <a href="#override-availability">configuration</a> for
+        the answer returned from {{getAvailability()}},
+        the UA must <a>queue a task</a> on
+        each <a>global object</a> |global|'s <a>responsible event loop</a>
+        to run the following steps:
       </p>
       <ol>
         <li>
-          Let |available| be `true` if the UA is newly able to use Bluetooth,
-          or `false` otherwise.
+          Let |oldAvailability| be
+          the value {{getAvailability()}} would have returned before the change.
         </li>
         <li>
-          For each <a>global object</a> |global|,
-          <a>queue a task</a> on its <a>responsible event loop</a> to
+          Let |newAvailability| be
+          the value {{getAvailability()}} would return after the change.
+        </li>
+        <li>
+          If |oldAvailability| is not the same as |newAvailability|,
           <a>fire an event</a> named {{availabilitychanged}}
           using the {{ValueEvent}} interface
           at <code>|global|.navigator.bluetooth</code>
-          with its {{ValueEvent/value}} attribute initialized to |available|.
+          with its {{ValueEvent/value}} attribute initialized to |newAvailability|.
         </li>
       </ol>
     </div>

--- a/index.bs
+++ b/index.bs
@@ -101,6 +101,9 @@ spec: WebIDL; urlPrefix: https://heycam.github.io/webidl/#
         text: a copy of the bytes held; url: dfn-get-buffer-source-copy
 </pre>
 <pre class="link-defaults">
+spec: fingerprinting-guidance
+    type: dfn
+        text: fingerprinting surface
 spec: html
     type: dfn
         text: global object; for: /
@@ -510,6 +513,24 @@ spec: html
         for a website to trigger a scan, which reduces the frequency of scans some,
         but it would still be better for more platforms to expose the <a>Privacy Feature</a>.
     </section>
+  </section>
+
+  <section class="non-normative">
+    <h3 id="availability-fingerprint">Exposing Bluetooth availability</h3>
+
+    <em>This section is non-normative.</em>
+
+    <p>
+      <code>navigator.bluetooth.{{getAvailability()}}</code>
+      exposes whether a Bluetooth radio is available on the user's system.
+      Some users might consider this private,
+      although it's hard to imagine the damage that would result from revealing it.
+      This information also increases the UA's <a>fingerprinting surface</a> by a bit.
+      This function returns a {{Promise}},
+      so UAs have the option of asking the user what value they want to return,
+      but we expect the increased risk to be small enough that
+      UAs will choose not to prompt.
+    </p>
   </section>
 </section>
 
@@ -1797,6 +1818,10 @@ spec: html
     <p>
       The <dfn attribute for="ValueEvent">value</dfn> attribute
       must return the value it was initialized to.
+    </p>
+
+    <p class="issue" id="ValueEvent-too-generic">
+      Such a generic event type belongs in [[HTML]] or [[DOM]], not here.
     </p>
   </section>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -1777,9 +1777,9 @@ spec: html
       to determine whether Bluetooth is available.
     </div>
 
-    <div algorithm="availabilitychanged">
+    <div algorithm="availabilitychanged" id="availability-changed-algorithm">
       <p>
-        If the UA becomes able or disable to use Bluetooth,
+        If the UA becomes able or unable to use Bluetooth,
         for example because a radio was physically attached or detached,
         the UA must run the following steps:
       </p>
@@ -4158,9 +4158,9 @@ spec: html
 
         <dt><dfn event for="Bluetooth"><code>availabilitychanged</code></dfn></dt>
         <dd>
-          Fired on {{Bluetooth|navigator.bluetooth}}
-          when the Bluetooth system as a whole
-          becomes available or unavailable to the UA.
+          Fired on {{Bluetooth|navigator.bluetooth}} when
+          <a href="#availability-changed-algorithm">the Bluetooth system as a whole
+          becomes available or unavailable to the UA</a>.
         </dd>
 
         <dt><dfn event for="BluetoothRemoteGATTCharacteristic"><code>characteristicvaluechanged</code></dfn></dt>


### PR DESCRIPTION
Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/expose-availability/index.bs#availability.

Thanks to @domenic for simplifying the overall design.

@npdoty can you see if you agree with the [privacy section](https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/expose-availability/index.bs#availability-fingerprint) or if there's something different I should say?