### PR TITLE
Add GATT blacklist link in "Attacks on devices"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -391,7 +391,7 @@ spec: html
       the trusted operating system of a remote device.
       Human Interface Devices are a prominent example,
       where allowing a website to communicate would allow that site to log keystrokes.
-      This specification includes a blacklist of
+      This specification includes a <a>GATT blacklist</a> of
       such vulnerable services, characteristics, and descriptors
       to prevent websites from taking advantage of them.
     </p>


### PR DESCRIPTION
Since  `SecurityError: requestDevice() called with a filter containing a blacklisted UUID. https://goo.gl/4NeimX` links to "Attack on devices" section, it would be nice to have a link the GATT Blacklist section.

Live preview at https://api.csswg.org/bikeshed/?url=https://github.com/WebBluetoothCG/web-bluetooth/raw/beaufortfrancois-patch-2/index.bs#attacks-on-devices