### PR TITLE
Throw a TypeError instead of a SyntaxError for bad UUIDs.

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -31,6 +31,7 @@ Get Characteristics List  | ✓         | ✓       | ✓   | ✓     |         
 Device Disconnected Event | ✓         | ✓       | ✓   | ✓     |         |
 Get Primary Services List | ✓         | ✓      | ✓   | ✓     |         |
 {start,stop}Notifications returns `this` | 54 | 54 | 54 | 54  |         |
+TypeError for bad UUIDs   |           |         |     |       |         |
 Advertisements Scanning   |           |         |     |       |         |
 Permissions API Integration |         |         |     |       |         |
 

--- a/index.bs
+++ b/index.bs
@@ -4873,7 +4873,7 @@ spec: html
           and return {{BluetoothUUID/canonicalUUID()|BluetoothUUID.canonicalUUID}}(<var>alias</var>)</code>.
         </li>
         <li>
-          Otherwise, throw a {{SyntaxError}}.
+          Otherwise, throw a {{TypeError}}.
         </li>
       </ol>
     </div>
@@ -4906,7 +4906,7 @@ spec: html
       </p>
       <p>
         <code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("unknown-service")</code>
-        throws a {{SyntaxError}}.
+        throws a {{TypeError}}.
       </p>
       <p>
         <code>{{BluetoothUUID/getCharacteristic()|BluetoothUUID.getCharacteristic}}("{{org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list|ieee_11073-20601_regulatory_certification_data_list}}")</code>


### PR DESCRIPTION
https://heycam.github.io/webidl/#idl-exceptions says that SyntaxError is
"for use only by the ECMAScript parser". We use TypeError for bad enums,
so it makes sense for malformatted UUID strings too.

Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/syntax-to-type-error/index.bs