### PR TITLE
Allow the UA to skip the chooser if no devices could appear in it.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1311,6 +1311,12 @@ spec: html
         If |state| is {{"denied"}}, return `[]` and abort these steps.
       </li>
       <li>
+        If the UA can prove that no devices could possibly be found in the next step,
+        for example because there is no Bluetooth adapter with which to scan,
+        or because the filters can't be matched by any possible advertising packet,
+        the UA MAY return `[]` and abort these steps.
+      </li>
+      <li>
         <a>Scan for devices</a> with
         <var>requiredServiceUUIDs</var>
         as the <i>set of <a>Service</a> UUIDs</i>,


### PR DESCRIPTION
Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/specify-early-request-failures/index.bs#request-bluetooth-devices

Fixes #296 

@dati91 