### PR TITLE
Allow UAs to reject concurrent use of 6 functions.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3231,6 +3231,16 @@ spec: html
           and abort these steps.
         </li>
         <li>
+          If the UA is currently using the Bluetooth system,
+          it MAY <a>queue a task</a> to <a>reject</a> |promise| with a {{NetworkError}},
+          return |promise|,
+          and abort these steps.
+
+          Issue(188): Implementations may be able to avoid this {{NetworkError}},
+          but for now sites need to serialize their use of this API
+          and/or give the user a way to retry failed operations.
+        </li>
+        <li>
           Add |promise| to <code>this.{{[[activeAlgorithms]]}}</code>.
         </li>
         <li>
@@ -3815,6 +3825,15 @@ spec: html
               <a>reject</a> <var>promise</var> with a {{NotSupportedError}} and abort these steps.
             </li>
             <li>
+              If the UA is currently using the Bluetooth system,
+              it MAY <a>reject</a> |promise| with a {{NetworkError}}
+              and abort these steps.
+
+              Issue(188): Implementations may be able to avoid this {{NetworkError}},
+              but for now sites need to serialize their use of this API
+              and/or give the user a way to retry failed operations.
+            </li>
+            <li>
               Use any combination of the sub-procedures in
               the <a>Characteristic Value Read</a> procedure
               to retrieve the value of <var>characteristic</var>.
@@ -3895,6 +3914,15 @@ spec: html
               If none of the <code>Write</code>, <code>Write Without Response</code> or <code>Authenticated Signed Writes</code> bits are set
               in <var>characteristic</var>'s <a lt="Characteristic Properties">properties</a>,
               <a>reject</a> <var>promise</var> with a {{NotSupportedError}} and abort these steps.
+            </li>
+            <li>
+              If the UA is currently using the Bluetooth system,
+              it MAY <a>reject</a> |promise| with a {{NetworkError}}
+              and abort these steps.
+
+              Issue(188): Implementations may be able to avoid this {{NetworkError}},
+              but for now sites need to serialize their use of this API
+              and/or give the user a way to retry failed operations.
             </li>
             <li>
               Use any combination of the sub-procedures in
@@ -3980,6 +4008,15 @@ spec: html
           If <code>this.service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code> is `false`,
           <a>reject</a> <var>promise</var> with a {{NetworkError}}
           and abort these steps.
+        </li>
+        <li>
+          If the UA is currently using the Bluetooth system,
+          it MAY <a>reject</a> |promise| with a {{NetworkError}}
+          and abort these steps.
+
+          Issue(188): Implementations may be able to avoid this {{NetworkError}},
+          but for now sites need to serialize their use of this API
+          and/or give the user a way to retry failed operations.
         </li>
         <li>
           Use any of the <a>Characteristic Descriptors</a> procedures
@@ -4266,6 +4303,15 @@ spec: html
           and run the following steps <a>in parallel</a>:
           <ol>
             <li>
+              If the UA is currently using the Bluetooth system,
+              it MAY <a>reject</a> |promise| with a {{NetworkError}}
+              and abort these steps.
+
+              Issue(188): Implementations may be able to avoid this {{NetworkError}},
+              but for now sites need to serialize their use of this API
+              and/or give the user a way to retry failed operations.
+            </li>
+            <li>
               Use either the <a>Read Characteristic Descriptors</a> or
               the <a>Read Long Characteristic Descriptors</a> sub-procedure
               to retrieve the value of <var>descriptor</var>.
@@ -4339,6 +4385,15 @@ spec: html
           <a>a new promise</a> <var>promise</var>
           and run the following steps in parallel.
           <ol>
+            <li>
+              If the UA is currently using the Bluetooth system,
+              it MAY <a>reject</a> |promise| with a {{NetworkError}}
+              and abort these steps.
+
+              Issue(188): Implementations may be able to avoid this {{NetworkError}},
+              but for now sites need to serialize their use of this API
+              and/or give the user a way to retry failed operations.
+            </li>
             <li>
               Use either the <a>Write Characteristic Descriptors</a> or
               the <a>Write Long Characteristic Descriptors</a> sub-procedure


### PR DESCRIPTION
Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/in-progress-error/index.bs#dom-bluetoothremotegattserver-connect.

* GattServer.connect()
* Characteristic.readValue()
* Characteristic.writeValue()
* Characteristic.startNotifications()
* Descriptor.readValue()
* Descriptor.writeValue()

This is uncomfortable because while serializing within a single realm
will reduce the frequency of these NetworkErrors, separate realms and
possibly other applications entirely can also cause these errors, and
the only way to recover is to retry and hope it doesn't happen again.

We're discussing the constraints imposed by the OS and the long-term
plan in #188. Any change should reduce the number of exceptions and so
be backward-compatible.