### PR TITLE
Add [SameObject] extended attribute to bluetooth

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5349,7 +5349,7 @@ spec: html
 
   <pre class="idl">
     partial interface Navigator {
-      readonly attribute Bluetooth bluetooth;
+      [SameObject] readonly attribute Bluetooth bluetooth;
     };
   </pre>
 </section>


### PR DESCRIPTION
I was taking a look at the WebIDL spec and noticed this property.

Preview at:

https://api.csswg.org/bikeshed/?url=https://github.com/g-ortuno/web-bluetooth/raw/same-object/index.bs
