### PR TITLE
Fix typo in GetPrimaryServices

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3498,7 +3498,7 @@ spec: html
           return <a>a promise rejected with</a> a {{SecurityError}} and abort these steps.
         </li>
         <li>
-          Return <a>GetGATTChildren</a>(<span class="argument-list"><i>attribute</i>=<code>this.device.{{BluetoothDevice/[[representedDevice]]}}</code>,<br>
+          Return <a>GetGATTChildren</a>(<span class="argument-list"><i>attribute</i>=<code>this.device</code>,<br>
           <i>single</i>=false,<br>
           <i>uuidCanonicalizer</i>={{BluetoothUUID/getService()|BluetoothUUID.getService}},<br>
           <i>uuid</i>=<code><var>service</var></code>,<br>


### PR DESCRIPTION
I think there is a typo in `GetPrimaryServices`, because `this{.device}` is used everywhere else but here.

Preview at https://api.csswg.org/bikeshed/?url=https://github.com/dati91/web-bluetooth/raw/gattchildren_typo/index.bs