### PR TITLE
Clearly mark invalid requestDevice example arguments.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -951,7 +951,7 @@ spec: html
             requestDevice({})
           </pre>
         </td>
-        <td>A absent list of filters doesn't accept any devices.</td>
+        <td>Invalid: An absent list of filters doesn't accept any devices.</td>
       </tr>
       <tr>
         <td>
@@ -959,7 +959,7 @@ spec: html
             requestDevice({filters:[]})
           </pre>
         </td>
-        <td>An empty list of filters doesn't accept any devices.</td>
+        <td>Invalid: An empty list of filters doesn't accept any devices.</td>
       </tr>
       <tr>
         <td>
@@ -967,7 +967,7 @@ spec: html
             requestDevice({filters:[{}]})
           </pre>
         </td>
-        <td>An empty filter accepts all devices, and so isn't allowed either.</td>
+        <td>Invalid: An empty filter accepts all devices, and so isn't allowed either.</td>
       </tr>
       <tr>
         <td>
@@ -978,8 +978,7 @@ spec: html
           </pre>
         </td>
         <td>
-          Explicitly accept all devices with {{acceptAllDevices}}.
-          This does <em>not</em> produce a {{TypeError}}.
+          Valid: Explicitly accept all devices with {{acceptAllDevices}}.
         </td>
       </tr>
       <tr>
@@ -991,7 +990,7 @@ spec: html
             })
           </pre>
         </td>
-        <td>{{acceptAllDevices}} would override any {{filters}}.</td>
+        <td>Invalid: {{acceptAllDevices}} would override any {{filters}}.</td>
       </tr>
       <tr>
         <td>
@@ -1001,7 +1000,7 @@ spec: html
             })
           </pre>
         </td>
-        <td>`namePrefix`, if present, must be non-empty to filter devices.</td>
+        <td>Invalid: `namePrefix`, if present, must be non-empty to filter devices.</td>
       </tr>
       <tr>
         <td>
@@ -1012,7 +1011,7 @@ spec: html
           </pre>
         </td>
         <td>
-          {{BluetoothLEScanFilterInit/manufacturerData}}, if present,
+          Invalid: {{BluetoothLEScanFilterInit/manufacturerData}}, if present,
           must be non-empty to filter devices.
         </td>
       </tr>
@@ -1025,7 +1024,7 @@ spec: html
           </pre>
         </td>
         <td>
-          {{BluetoothLEScanFilterInit/serviceData}}, if present,
+          Invalid: {{BluetoothLEScanFilterInit/serviceData}}, if present,
           must be non-empty to filter devices.
         </td>
       </tr>


### PR DESCRIPTION
The long list of examples has confused readers who arrived when searching for 
one pattern in particular. They saw the example and did not understand that
it was in a list where most examples were invalid. This change clearly marks
each example as valid or invalid.

https://api.csswg.org/bikeshed/?url=https://github.com/WebBluetoothCG/web-bluetooth/raw/invalid-request-device-examples/index.bs#example-disallowed-filters