### PR TITLE
Add [SameObject] to all unchanging interface attributes.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -588,7 +588,7 @@ spec: html
       Promise&lt;boolean> getAvailability();
       [SecureContext]
       attribute EventHandler onavailabilitychanged;
-      [SecureContext]
+      [SecureContext, SameObject]
       readonly attribute BluetoothDevice? referringDevice;
       [SecureContext]
       Promise&lt;BluetoothDevice> requestDevice(optional RequestDeviceOptions options);
@@ -2472,13 +2472,16 @@ spec: html
         };
         [Constructor(DOMString type, BluetoothAdvertisingEventInit init)]
         interface BluetoothAdvertisingEvent : Event {
+          [SameObject]
           readonly attribute BluetoothDevice device;
           readonly attribute FrozenArray&lt;UUID> uuids;
           readonly attribute DOMString? name;
           readonly attribute unsigned short? appearance;
           readonly attribute byte? txPower;
           readonly attribute byte? rssi;
+          [SameObject]
           readonly attribute BluetoothManufacturerDataMap manufacturerData;
+          [SameObject]
           readonly attribute BluetoothServiceDataMap serviceData;
         };
         dictionary BluetoothAdvertisingEventInit : EventInit {
@@ -3183,6 +3186,7 @@ spec: html
 
     <pre class="idl">
       interface BluetoothRemoteGATTServer {
+        [SameObject]
         readonly attribute BluetoothDevice device;
         readonly attribute boolean connected;
         Promise&lt;BluetoothRemoteGATTServer> connect();
@@ -3519,6 +3523,7 @@ spec: html
 
     <pre class="idl">
       interface BluetoothRemoteGATTService {
+        [SameObject]
         readonly attribute BluetoothDevice device;
         readonly attribute UUID uuid;
         readonly attribute boolean isPrimary;
@@ -3682,6 +3687,7 @@ spec: html
 
     <pre class="idl">
       interface BluetoothRemoteGATTCharacteristic {
+        [SameObject]
         readonly attribute BluetoothRemoteGATTService service;
         readonly attribute UUID uuid;
         readonly attribute BluetoothCharacteristicProperties properties;
@@ -4223,6 +4229,7 @@ spec: html
 
     <pre class="idl">
       interface BluetoothRemoteGATTDescriptor {
+        [SameObject]
         readonly attribute BluetoothRemoteGATTCharacteristic characteristic;
         readonly attribute UUID uuid;
         readonly attribute DataView? value;
@@ -5348,7 +5355,8 @@ spec: html
 
   <pre class="idl">
     partial interface Navigator {
-      [SameObject] readonly attribute Bluetooth bluetooth;
+      [SameObject]
+      readonly attribute Bluetooth bluetooth;
     };
   </pre>
 </section>


### PR DESCRIPTION
https://heycam.github.io/webidl/#SameObject says we can only use it on
interfaces, not Promises, FrozenArrays, primitive types, or nullable interfaces.

Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/same-object/index.bs