### PR TITLE
Fixes for the Permission API integration part.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1947,24 +1947,13 @@ spec: html
                 If <code><var>desc</var>.filters</code> is set, do the following sub-steps:
                 <ol>
                   <li>
-                    Let <var>uuidFilters</var> be a new {{Array}},
-                  </li>
-                  <li>
-                    For each |filter| in <code><var>desc</var>.filters</code>, do the following sub-steps:
-                    <ol>
-                      <li>
-                        Let |canonicalFilter| be
-                        the result of <a for="BluetoothLEScanFilterInit">canonicalizing</a> |filter|.
-                        If this step returns an error, return that error and abort these steps.
-                      </li>
-                      <li>
-                        Append |canonicalFilter| to |uuidFilters|.
-                      </li>
-                    </ol>
+                    Replace each filter in <code>|desc|.filters</code>
+                    with the result of <a for="BluetoothLEScanFilterInit">canonicalizing</a> it.
+                    If any of these canonicalizations throws an error, return that error and abort these steps.
                   </li>
                   <li>
                     If <code><var>allowedDevice</var>.{{[[device]]}}</code> does not
-                    <a>match a filter</a> in <var>uuidFilters</var>,
+                    <a>match a filter</a> in <code>|desc|.filters</code>,
                     continue to the next <var>allowedDevice</var>.
                   </li>
                 </ol>

--- a/index.bs
+++ b/index.bs
@@ -1944,14 +1944,33 @@ spec: html
                 continue to the next <var>allowedDevice</var>.
               </li>
               <li>
-                If <code><var>desc</var>.filters</code> is set
-                and <code><var>allowedDevice</var>.{{[[device]]}}</code> does not
-                <a>match a filter</a> in <code><var>desc</var>.filters</code>,
-                continue to the next <var>allowedDevice</var>.
+                If <code><var>desc</var>.filters</code> is set, do the following sub-steps:
+                <ol>
+                  <li>
+                    Let <var>uuidFilters</var> be a new {{Array}},
+                  </li>
+                  <li>
+                    For each |filter| in <code><var>desc</var>.filters</code>, do the following sub-steps:
+                    <ol>
+                      <li>
+                        Let |canonicalFilter| be
+                        the result of <a for="BluetoothLEScanFilterInit">canonicalizing</a> |filter|.
+                        If this step returns an error, return that error and abort these steps.
+                      </li>
+                      <li>
+                        Append |canonicalFilter| to |uuidFilters|.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>
+                    If <code><var>allowedDevice</var>.{{[[device]]}}</code> does not
+                    <a>match a filter</a> in <var>uuidFilters</var>,
+                    continue to the next <var>allowedDevice</var>.
+                  </li>
+                </ol>
               </li>
-              <li class="note">
+
                 Note: The <code>|desc|.optionalServices</code> field does not affect the result.
-              </li>
               <li>
                 <a>Get the `BluetoothDevice` representing</a>
                 <code><var>allowedDevice</var>.{{[[device]]}}</code>

--- a/index.bs
+++ b/index.bs
@@ -1958,8 +1958,6 @@ spec: html
                   </li>
                 </ol>
               </li>
-
-                Note: The <code>|desc|.optionalServices</code> field does not affect the result.
               <li>
                 <a>Get the `BluetoothDevice` representing</a>
                 <code><var>allowedDevice</var>.{{[[device]]}}</code>
@@ -1967,6 +1965,9 @@ spec: html
                 and add the result to <var>matchingDevices</var>.
               </li>
             </ol>
+            <p class="note">
+              Note: The <code>|desc|.optionalServices</code> field does not affect the result.
+            </p>
           </li>
           <li>
             Set <code><var>status</var>.devices</code> to


### PR DESCRIPTION
This PR fixes #347, also removes the numbering from the Note element in the query algorithm.


Preview at https://api.csswg.org/bikeshed/?url=https://github.com/zakorgy/web-bluetooth/raw/permission-request/index.bs#query-the-bluetooth-permission.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webbluetoothcg/web-bluetooth/349)
<!-- Reviewable:end -->
