### PR TITLE
Use the [[BackingMap]] provided by the ES maplike binding.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2742,7 +2742,7 @@ spec: html
               </li>
               <li>
                 Add a mapping from <var>code</var> to <code>new DataView(<var>bytes</var>)</code>
-                in <code><var>event</var>.manufacturerData.{{BluetoothManufacturerDataMap/[[data]]}}</code>.
+                in <code><var>event</var>.manufacturerData.{{BluetoothManufacturerDataMap/[[BackingMap]]}}</code>.
               </li>
             </ol>
           </li>
@@ -2768,7 +2768,7 @@ spec: html
               </li>
               <li>
                 Add a mapping from <var>service</var> to <code>new DataView(<var>bytes</var>)</code>
-                in <code><var>event</var>.serviceData.{{BluetoothServiceDataMap/[[data]]}}</code>.
+                in <code><var>event</var>.serviceData.{{BluetoothServiceDataMap/[[BackingMap]]}}</code>.
               </li>
             </ol>
           </li>
@@ -2780,28 +2780,10 @@ spec: html
         <h5 dfn-type="interface">BluetoothManufacturerDataMap</h5>
 
         <p>
-          Instances of {{BluetoothManufacturerDataMap}} are created with the <a>internal slots</a>
-          described in the following table:
-        </p>
-
-        <table class="data" dfn-for="BluetoothManufacturerDataMap" dfn-type="attribute">
-          <thead>
-            <th><a>Internal Slot</a></th>
-            <th>Initial Value</th>
-            <th>Description (non-normative)</th>
-          </thead>
-          <tr>
-            <td><dfn>\[[data]]</dfn></td>
-            <td><code>new {{Map}}()</code></td>
-            <td>
-              The advertised manufacturer data, converted to {{DataView}}s.
-            </td>
-          </tr>
-        </table>
-
-        <p>
-          The <a>map entries</a> of a {{BluetoothManufacturerDataMap}} instance are
-          the entries in <code>{{BluetoothManufacturerDataMap/[[data]]}}</code>.
+          Instances of {{BluetoothManufacturerDataMap}} have a
+          <dfn for="BluetoothManufacturerDataMap" dfn-type="attribute">`[[BackingMap]]`</dfn>
+          slot because they are [=maplike=], which maps manufacturer codes to
+          the manufacturer's data, converted to {{DataView}}s.
         </p>
       </section>
 
@@ -2809,28 +2791,10 @@ spec: html
         <h5 dfn-type="interface">BluetoothServiceDataMap</h5>
 
         <p>
-          Instances of {{BluetoothServiceDataMap}} are created with the <a>internal slots</a>
-          described in the following table:
-        </p>
-
-        <table class="data" dfn-for="BluetoothServiceDataMap" dfn-type="attribute">
-          <thead>
-            <th><a>Internal Slot</a></th>
-            <th>Initial Value</th>
-            <th>Description (non-normative)</th>
-          </thead>
-          <tr>
-            <td><dfn>\[[data]]</dfn></td>
-            <td><code>new {{Map}}()</code></td>
-            <td>
-              The advertised service data, converted to {{DataView}}s.
-            </td>
-          </tr>
-        </table>
-
-        <p>
-          The <a>map entries</a> of a {{BluetoothServiceDataMap}} instance are
-          the entries in <code>{{BluetoothServiceDataMap/[[data]]}}</code>.
+          Instances of {{BluetoothServiceDataMap}} have a
+          <dfn for="BluetoothServiceDataMap" dfn-type="attribute">`[[BackingMap]]`</dfn>
+          slot because they are [=maplike=], which maps service UUIDs to the
+          service's data, converted to {{DataView}}s.
         </p>
       </section>
     </section>


### PR DESCRIPTION
Instead of a custom [[data]] slot that also holds an EcmaScript Map.

Fixes #340 

Preview at https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/jyasskin/web-bluetooth-1/use-backing-map/index.bs#dom-bluetoothadvertisingevent-bluetoothadvertisingevent