### PR TITLE
Allow the UA to bond while connecting.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3274,6 +3274,17 @@ spec: html
                   The UA MAY attempt to bond with the remote device using
                   the <a>BR/EDR Bonding Procedure</a> or
                   the <a>LE Bonding Procedure</a>.
+
+                  Note: We would normally prefer to give the website control
+                  over whether and when bonding happens,
+                  but the [Core Bluetooth](https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/AboutCoreBluetooth/Introduction.html)
+                  platform API doesn't provide a way for UAs to implement such a knob.
+                  Having a bond is more secure than not having one,
+                  so this specification allows the UA to opportunistically create one
+                  on platforms where that's possible.
+                  This may cause a user-visible pairing dialog to appear
+                  when a connection is created,
+                  instead of when a restricted characteristic is accessed.
                 </li>
               </ol>
             </li>

--- a/index.bs
+++ b/index.bs
@@ -3270,6 +3270,11 @@ spec: html
                   Use the <a>Exchange MTU</a> procedure to negotiate the largest supported MTU.
                   Ignore any errors from this step.
                 </li>
+                <li>
+                  The UA MAY attempt to bond with the remote device using
+                  the <a>BR/EDR Bonding Procedure</a> or
+                  the <a>LE Bonding Procedure</a>.
+                </li>
               </ol>
             </li>
             <li>
@@ -5474,6 +5479,7 @@ spec: html
                 <li value="6">Idle Mode Procedures &mdash; BR/EDR Physical Transport
                   <ol>
                     <li value="4"><dfn>Device Discovery Procedure</dfn></li>
+                    <li value="5"><dfn>BR/EDR Bonding Procedure</dfn></li>
                   </ol>
                 </li>
                 <li value="9">Operational Modes and Procedures &mdash; LE Physical Transport
@@ -5490,6 +5496,11 @@ spec: html
                       </ol>
                     </li>
                     <li value="3"><dfn>Connection Modes and Procedures</dfn></li>
+                    <li value="4">Bonding Modes and Procedures
+                      <ol>
+                        <li value="4"><dfn>LE Bonding Procedure</dfn></li>
+                      </ol>
+                    </li>
                   </ol>
                 </li>
                 <li value="10">Security Aspects &mdash; LE Physical Transport


### PR DESCRIPTION
Fixes #346.

My impression is that we can't control Mac's bonding behavior, so we can't provide a function to let the website request bonding. Having a bond seems like it's always more secure than not having one, and the main downside of trying to bond would be that we might show a pin-entry dialog if that's the pairing method the devices negotiate. Showing that dialog on connection seems better than showing it when the first secure characteristic is accessed.