### PR TITLE
Add link for the request bluetooth permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1875,7 +1875,8 @@ spec: html
       </dt>
       <dd algorithm="permission request">
         <p>
-          Given a {{BluetoothPermissionDescriptor}} <var>options</var>
+          To <dfn>request the "bluetooth" permission</dfn> with
+          a {{BluetoothPermissionDescriptor}} <var>options</var>
           and a {{BluetoothPermissionResult}} <var>status</var>,
           the UA MUST run the following steps:
         </p>


### PR DESCRIPTION
Add a link for the bluetooth permission request part, make it referenceable by code writers .

Preview at: https://api.csswg.org/bikeshed/?url=https://github.com/zakorgy/web-bluetooth/raw/permission-request-link/index.bs#request-the-bluetooth-permission

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webbluetoothcg/web-bluetooth/353)
<!-- Reviewable:end -->
