### PR TITLE
Reorder startNotifications steps

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3986,6 +3986,11 @@ spec: html
           <a>reject</a> <var>promise</var> with a {{SecurityError}} and abort these steps.
         </li>
         <li>
+          If <code>this.service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code> is `false`,
+          <a>reject</a> <var>promise</var> with a {{NetworkError}}
+          and abort these steps.
+        </li>
+        <li>
           Let |characteristic| be
           <code>this.{{[[representedCharacteristic]]}}</code>.
         </li>
@@ -4003,11 +4008,6 @@ spec: html
           If <var>characteristic</var>'s <a>active notification context set</a> contains
           {{Navigator/bluetooth|navigator.bluetooth}},
           <a>resolve</a> <var>promise</var> with `this` and abort these steps.
-        </li>
-        <li>
-          If <code>this.service.device.gatt.{{BluetoothRemoteGATTServer/connected}}</code> is `false`,
-          <a>reject</a> <var>promise</var> with a {{NetworkError}}
-          and abort these steps.
         </li>
         <li>
           If the UA is currently using the Bluetooth system,


### PR DESCRIPTION
Fixes  #341.
Preview at https://api.csswg.org/bikeshed/?url=https://github.com/zakorgy/web-bluetooth/raw/reorder-startnot-steps/index.bs#dom-bluetoothremotegattcharacteristic-startnotifications

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/webbluetoothcg/web-bluetooth/355)
<!-- Reviewable:end -->
