### PR TITLE
Fix the link for TestRunner.getBluetoothManualChooserEvents(callback).

### DIFF
--- a/tests.bs
+++ b/tests.bs
@@ -237,7 +237,7 @@ that records events that would otherwise be shown to the user (see
 interaction with the prompt (see
 {{TestRunner/sendBluetoothManualChooserEvent()}}).
 
-<h3 dfn-type="method" for="TestRunner">getBluetoothManualChooserEvents()</h3>
+<h3 dfn-type="method" for="TestRunner">getBluetoothManualChooserEvents(callback)</h3>
 
 When invoked, {{TestRunner/getBluetoothManualChooserEvents(callback)}} MUST call `callback` with the
 list of events that have been recorded by the <a>manual chooser</a> since


### PR DESCRIPTION
Fixes #373