### PR TITLE
Handle notifications for characteristics missing a CCCD

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4044,7 +4044,8 @@ spec: html
           and/or give the user a way to retry failed operations.
         </li>
         <li>
-          Use any of the <a>Characteristic Descriptors</a> procedures
+          If the characteristic has a <a>Client Characteristic Configuration</a>
+          descriptor, use any of the <a>Characteristic Descriptors</a> procedures
           to ensure that one of the <code>Notification</code> or <code>Indication</code> bits in
           <var>characteristic</var>'s <a>Client Characteristic Configuration</a> descriptor
           is set, matching the constraints
@@ -4053,6 +4054,13 @@ spec: html
           and MUST deduplicate <a href="#notification-events">value-change events</a>
           if both bits are set.
           Handle errors as described in <a href="#error-handling"></a>.
+
+          Note: Some devices have characteristics whose properties include the
+          Notify or Indicate bit but that don't have a <a>Client Characteristic
+          Configuration</a> descriptor. These non-standard-compliant characteristics
+          tend to send notifications or indications unconditionally, so this
+          specification allows applications to simply subscribe to their
+          messages.
         </li>
         <li>
           If the previous step returned an error,
@@ -4099,7 +4107,8 @@ spec: html
           remove it.
         </li>
         <li>
-          If <var>characteristic</var>'s <a>active notification context set</a> became empty,
+          If <var>characteristic</var>'s <a>active notification context set</a> became empty
+          and the characteristic has a <a>Client Characteristic Configuration</a> descriptor,
           the UA SHOULD use any of the <a>Characteristic Descriptors</a> procedures
           to clear the <code>Notification</code> and <code>Indication</code> bits in
           <var>characteristic</var>'s <a>Client Characteristic Configuration</a> descriptor.
@@ -4626,7 +4635,9 @@ spec: html
               <li>
                 If |notificationContexts| became empty
                 and there is still an <a>ATT Bearer</a>
-                to <code>|deviceObj|.{{[[representedDevice]]}}</code>,
+                to <code>|deviceObj|.{{[[representedDevice]]}}</code>
+                and <var>characteristic</var> has a <a>Client Characteristic
+                Configuration</a> descriptor,
                 the UA SHOULD use any of the <a>Characteristic Descriptors</a> procedures
                 to clear the <code>Notification</code> and <code>Indication</code> bits in
                 <var>characteristic</var>'s <a>Client Characteristic Configuration</a> descriptor.


### PR DESCRIPTION
A common violation of the specification is characteristics with
notification/indication capabilities not having an associated
Client Characteristic Configuration descriptor (CCCD).

In order to allow compatability with these types of devices,
implementaions should still attempt to register notifications on
characteristics without a CCD.