### PR TITLE
Replace "non-`null`" with "not `null`"

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -759,19 +759,19 @@ spec:web-bluetooth
       </p>
       <ul>
         <li>
-          If <code>|filter|.name</code> is non-`null`,
+          If <code>|filter|.name</code> is non-<code>null</code>,
           |event| has a <a>Local Name</a> equal to <code>|filter|.name</code>.
 
           Note: A <a>Shortened Local Name</a>
           can match a {{BluetoothLEScanFilter/name}} filter.
         </li>
         <li>
-          If <code>|filter|.namePrefix</code> is non-`null`,
+          If <code>|filter|.namePrefix</code> is non-<code>null</code>,
           |event| has a <a>Local Name</a>,
           and <code>|filter|.namePrefix</code> is a prefix of it.
         </li>
         <li>
-          If <code>|filter|.serviceUUID</code> is non-`null`,
+          If <code>|filter|.serviceUUID</code> is non-<code>null</code>,
           it is equal to a <a>Service UUID</a> in |event|.
         </li>
         <li>


### PR DESCRIPTION
Bikeshed compilation fails when encountering the former with,

"Unknown inline tag: non-`null`"

Replacing this with "not `null`" does not change the meaning.