### PR TITLE
Fix warnings for unexported definitions

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1878,7 +1878,7 @@ spec: promises-guide-1
       </dt>
       <dd algorithm="permission request">
         <p>
-          To <dfn>request the "bluetooth" permission</dfn> with
+          To <dfn export>request the "bluetooth" permission</dfn> with
           a {{BluetoothPermissionDescriptor}} <var>options</var>
           and a {{BluetoothPermissionResult}} <var>status</var>,
           the UA MUST run the following steps:
@@ -1914,7 +1914,7 @@ spec: promises-guide-1
         <a>permission query algorithm</a>
       </dt>
       <dd algorithm>
-        To <dfn>query the "bluetooth" permission</dfn> with
+        To <dfn export>query the "bluetooth" permission</dfn> with
         a {{BluetoothPermissionDescriptor}} <var>desc</var>
         and a {{BluetoothPermissionResult}} <var>status</var>, the UA must:
         <ol>
@@ -2203,7 +2203,7 @@ spec: promises-guide-1
       </li>
 
       <li>
-        A hierarchy of GATT attributes, described in [[#information-model]].
+        A hierarchy of GATT <a>Attributes</a>.
       </li>
     </ul>
 
@@ -5530,7 +5530,7 @@ spec: promises-guide-1
                         <li value="7"><dfn>Name Discovery Procedure</dfn></li>
                       </ol>
                     </li>
-                    <li value="3"><dfn>Connection Modes and Procedures</dfn></li>
+                    <li value="3">Connection Modes and Procedures</li>
                     <li value="4">Bonding Modes and Procedures
                       <ol>
                         <li value="4"><dfn>LE Bonding Procedure</dfn></li>
@@ -5655,18 +5655,18 @@ spec: promises-guide-1
                     </li>
                     <li value="4"><dfn>Primary Service Discovery</dfn>
                       <ol>
-                        <li value="1"><dfn>Discover All Primary Services</dfn></li>
+                        <li value="1">Discover All Primary Services</li>
                         <li value="2"><dfn>Discover Primary Service by Service UUID</dfn></li>
                       </ol>
                     </li>
                     <li value="5"><dfn>Relationship Discovery</dfn>
                       <ol>
-                        <li value="1"><dfn>Find Included Services</dfn></li>
+                        <li value="1">Find Included Services</li>
                       </ol>
                     </li>
                     <li value="6"><dfn>Characteristic Discovery</dfn>
                       <ol>
-                        <li value="1"><dfn>Discover All Characteristics of a Service</dfn></li>
+                        <li value="1">Discover All Characteristics of a Service</li>
                         <li value="2"><dfn>Discover Characteristics by UUID</dfn></li>
                       </ol>
                     </li>

--- a/scanning.bs
+++ b/scanning.bs
@@ -922,10 +922,10 @@ spec:web-bluetooth
                       <ol>
                         <li value="1">Advertising PDUs
                           <ol>
-                            <li value="1"><dfn>ADV_IND</dfn></li>
-                            <li value="2"><dfn>ADV_DIRECT_IND</dfn></li>
-                            <li value="3"><dfn>ADV_NONCONN_IND</dfn></li>
-                            <li value="4"><dfn>ADV_SCAN_IND</dfn></li>
+                            <li value="1">ADV_IND</li>
+                            <li value="2">ADV_DIRECT_IND</li>
+                            <li value="3">ADV_NONCONN_IND</li>
+                            <li value="4">ADV_SCAN_IND</li>
                           </ol>
                         </li>
                       </ol>
@@ -963,7 +963,7 @@ spec:web-bluetooth
                 <li value="1">
                   <dfn>Local Name</dfn>
                   also defines <dfn>Shortened Local Name</dfn>
-                  and <dfn>Complete Local Name</dfn>
+                  and Complete Local Name
                 </li>
                 <li value="4"><dfn>Manufacturer Specific Data</dfn></li>
                 <li value="11"><dfn>Service Data</dfn></li>

--- a/tests.bs
+++ b/tests.bs
@@ -210,8 +210,8 @@ In addition to the properties of a
 
 <h4 dfn-type="dfn">FailingGATTOperationsDevice</h4>
 
-Let <dfn dfn><code>errorUUID(unsigned long id)</code></dfn> be the <a>valid
-UUID</a> consisting of <code>id.toString(16)</code> left-padded with
+Let <code><dfn abstract-op>errorUUID</dfn>(unsigned long id)</code> be the
+<a>valid UUID</a> consisting of <code>id.toString(16)</code> left-padded with
 <code>"0"</code>s to 8 characters, and then concatenated with
 <code>"-97e5-4cd7-b9f1-f5a427670c59"</code>. (These lower 96 bits were generated
 as a type 4 (random) UUID.)
@@ -220,11 +220,11 @@ The
 <a>FailingGATTOperationsDevice</a> has a MAC address of
 <code>00:00:00:00:00:00</code>, the name <code>"Errors Device"</code>, and
 accepts GATT connections. Its GATT Server contains one service with UUID
-<code>errorUUID(0x100)</code>. This service contains 255 characteristics with
-UUIDs <code>errorUUID(0x101)</code> through <code>errorUUID(0x1ff)</code>. When
-read or written, the characteristic with UUID <code>errorUUID(which)</code>
-returns an Error Response ([[!BLUETOOTH42]] 3.F.3.4.1.1) with an error code of
-<code>which - 0x100</code>.
+<code>[$errorUUID$](0x100)</code>. This service contains 255 characteristics
+with UUIDs <code>[$errorUUID$](0x101)</code> through
+<code>[$errorUUID$](0x1ff)</code>. When read or written, the characteristic with
+UUID <code>[$errorUUID$](which)</code> returns an Error Response
+([[!BLUETOOTH42]] 3.F.3.4.1.1) with an error code of <code>which - 0x100</code>.
 
 
 <h3 dfn-type="method" for="TestRunner">setBluetoothManualChooser()</h3>


### PR DESCRIPTION
This patch exports definitions related to Permissions API integration, adds a few references to unexported definitions where they are appropriate and removes a few definitions that are unused.