### PR TITLE
Add a PR-Preview configuration file

### DIFF
--- a/.pr-preview.json
+++ b/.pr-preview.json
@@ -1,0 +1,7 @@
+{
+    "src_file": "index.bs",
+    "type": "bikeshed",
+    "params": {
+        "force": 1
+    }
+}


### PR DESCRIPTION
See https://github.com/tobie/pr-preview#configuration-file for documentation.

This only supports the main Web Bluetooth specification. https://github.com/tobie/pr-preview/issues/18 tracks being able to preview the scanning spec as well.