### PR TITLE
Add [SecureContext] to navigator.bluetooth

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5355,8 +5355,9 @@ spec: promises-guide-1
   <h2 id="navigator-extensions">Extensions to the Navigator Interface</h2>
 
   <pre class="idl">
+    [SecureContext]
     partial interface Navigator {
-      [SameObject, SecureContext]
+      [SameObject]
       readonly attribute Bluetooth bluetooth;
     };
   </pre>

--- a/index.bs
+++ b/index.bs
@@ -5359,7 +5359,7 @@ spec: promises-guide-1
 
   <pre class="idl">
     partial interface Navigator {
-      [SameObject]
+      [SameObject, SecureContext]
       readonly attribute Bluetooth bluetooth;
     };
   </pre>

--- a/index.bs
+++ b/index.bs
@@ -587,13 +587,10 @@ spec: promises-guide-1
     };
 
     interface Bluetooth : EventTarget {
-      [SecureContext]
       Promise&lt;boolean> getAvailability();
-      [SecureContext]
       attribute EventHandler onavailabilitychanged;
-      [SecureContext, SameObject]
+      [SameObject]
       readonly attribute BluetoothDevice? referringDevice;
-      [SecureContext]
       Promise&lt;BluetoothDevice> requestDevice(optional RequestDeviceOptions options);
     };
     Bluetooth implements BluetoothDeviceEventHandlers;


### PR DESCRIPTION
It is tricky sometimes to know why the Web Bluetooth API is not "working" as `navigator.bluetooth` is available in HTTP, but `navigator.bluetooth.requestDevice` only in HTTPS. I propose adding `[SecureContext]` to `navigator.bluetooth` as well.

WDYT @jyasskin 

CC @g-ortuno


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/401.html" title="Last updated on Jul 6, 2018, 4:11 PM GMT (e7a3afb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/401/68c5a71...e7a3afb.html" title="Last updated on Jul 6, 2018, 4:11 PM GMT (e7a3afb)">Diff</a>