### PR TITLE
Add [Exposed] and migrate to new mixin syntax

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2232,8 +2232,8 @@ spec: promises-guide-1
     </p>
 
     <pre class="idl">
-      interface BluetoothDevice {
       [Exposed=Window, SecureContext]
+      interface BluetoothDevice : EventTarget {
         readonly attribute DOMString id;
         readonly attribute DOMString? name;
         readonly attribute BluetoothRemoteGATTServer? gatt;
@@ -2242,7 +2242,6 @@ spec: promises-guide-1
         void unwatchAdvertisements();
         readonly attribute boolean watchingAdvertisements;
       };
-      BluetoothDevice implements EventTarget;
       BluetoothDevice implements BluetoothDeviceEventHandlers;
       BluetoothDevice implements CharacteristicEventHandlers;
       BluetoothDevice implements ServiceEventHandlers;
@@ -3525,8 +3524,8 @@ spec: promises-guide-1
     </p>
 
     <pre class="idl">
-      interface BluetoothRemoteGATTService {
       [Exposed=Window, SecureContext]
+      interface BluetoothRemoteGATTService : EventTarget {
         [SameObject]
         readonly attribute BluetoothDevice device;
         readonly attribute UUID uuid;
@@ -3540,7 +3539,6 @@ spec: promises-guide-1
         Promise&lt;sequence&lt;BluetoothRemoteGATTService>>
           getIncludedServices(optional BluetoothServiceUUID service);
       };
-      BluetoothRemoteGATTService implements EventTarget;
       BluetoothRemoteGATTService implements CharacteristicEventHandlers;
       BluetoothRemoteGATTService implements ServiceEventHandlers;
     </pre>
@@ -3690,8 +3688,8 @@ spec: promises-guide-1
     <p>{{BluetoothRemoteGATTCharacteristic}} represents a GATT <a>Characteristic</a>, which is a basic data element that provides further information about a peripheral's service.</p>
 
     <pre class="idl">
-      interface BluetoothRemoteGATTCharacteristic {
       [Exposed=Window, SecureContext]
+      interface BluetoothRemoteGATTCharacteristic : EventTarget {
         [SameObject]
         readonly attribute BluetoothRemoteGATTService service;
         readonly attribute UUID uuid;
@@ -3705,7 +3703,6 @@ spec: promises-guide-1
         Promise&lt;BluetoothRemoteGATTCharacteristic> startNotifications();
         Promise&lt;BluetoothRemoteGATTCharacteristic> stopNotifications();
       };
-      BluetoothRemoteGATTCharacteristic implements EventTarget;
       BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;
     </pre>
 

--- a/index.bs
+++ b/index.bs
@@ -593,9 +593,9 @@ spec: promises-guide-1
       readonly attribute BluetoothDevice? referringDevice;
       Promise&lt;BluetoothDevice> requestDevice(optional RequestDeviceOptions options);
     };
-    Bluetooth implements BluetoothDeviceEventHandlers;
-    Bluetooth implements CharacteristicEventHandlers;
-    Bluetooth implements ServiceEventHandlers;
+    Bluetooth includes BluetoothDeviceEventHandlers;
+    Bluetooth includes CharacteristicEventHandlers;
+    Bluetooth includes ServiceEventHandlers;
   </pre>
   <div class="note" heading="{{Bluetooth}} members">
     <p>
@@ -2242,9 +2242,9 @@ spec: promises-guide-1
         void unwatchAdvertisements();
         readonly attribute boolean watchingAdvertisements;
       };
-      BluetoothDevice implements BluetoothDeviceEventHandlers;
-      BluetoothDevice implements CharacteristicEventHandlers;
-      BluetoothDevice implements ServiceEventHandlers;
+      BluetoothDevice includes BluetoothDeviceEventHandlers;
+      BluetoothDevice includes CharacteristicEventHandlers;
+      BluetoothDevice includes ServiceEventHandlers;
     </pre>
 
     <div class="note" heading="{{BluetoothDevice}} attributes"
@@ -3539,8 +3539,8 @@ spec: promises-guide-1
         Promise&lt;sequence&lt;BluetoothRemoteGATTService>>
           getIncludedServices(optional BluetoothServiceUUID service);
       };
-      BluetoothRemoteGATTService implements CharacteristicEventHandlers;
-      BluetoothRemoteGATTService implements ServiceEventHandlers;
+      BluetoothRemoteGATTService includes CharacteristicEventHandlers;
+      BluetoothRemoteGATTService includes ServiceEventHandlers;
     </pre>
 
     <div class="note" heading="{{BluetoothRemoteGATTService}} attributes"
@@ -3703,7 +3703,7 @@ spec: promises-guide-1
         Promise&lt;BluetoothRemoteGATTCharacteristic> startNotifications();
         Promise&lt;BluetoothRemoteGATTCharacteristic> stopNotifications();
       };
-      BluetoothRemoteGATTCharacteristic implements CharacteristicEventHandlers;
+      BluetoothRemoteGATTCharacteristic includes CharacteristicEventHandlers;
     </pre>
 
     <div class="note" heading="{{BluetoothRemoteGATTCharacteristic}} attributes"
@@ -4966,8 +4966,8 @@ spec: promises-guide-1
       <h4 id="idl-event-handlers">IDL event handlers</h4>
 
       <pre class="idl">
-        [NoInterfaceObject, SecureContext]
-        interface CharacteristicEventHandlers {
+        [SecureContext]
+        interface mixin CharacteristicEventHandlers {
           attribute EventHandler oncharacteristicvaluechanged;
         };
       </pre>
@@ -4978,8 +4978,8 @@ spec: promises-guide-1
       </p>
 
       <pre class="idl">
-        [NoInterfaceObject, SecureContext]
-        interface BluetoothDeviceEventHandlers {
+        [SecureContext]
+        interface mixin BluetoothDeviceEventHandlers {
           attribute EventHandler ongattserverdisconnected;
         };
       </pre>
@@ -4990,8 +4990,8 @@ spec: promises-guide-1
       </p>
 
       <pre class="idl">
-        [NoInterfaceObject, SecureContext]
-        interface ServiceEventHandlers {
+        [SecureContext]
+        interface mixin ServiceEventHandlers {
           attribute EventHandler onserviceadded;
           attribute EventHandler onservicechanged;
           attribute EventHandler onserviceremoved;

--- a/index.bs
+++ b/index.bs
@@ -585,7 +585,7 @@ spec: promises-guide-1
       boolean acceptAllDevices = false;
     };
 
-    [SecureContext]
+    [Exposed=Window, SecureContext]
     interface Bluetooth : EventTarget {
       Promise&lt;boolean> getAvailability();
       attribute EventHandler onavailabilitychanged;
@@ -1865,6 +1865,7 @@ spec: promises-guide-1
       </dt>
       <dd>
         <pre class="idl">
+          [Exposed=Window]
           interface BluetoothPermissionResult : PermissionStatus {
             attribute FrozenArray&lt;BluetoothDevice> devices;
           };
@@ -2114,6 +2115,7 @@ spec: promises-guide-1
 
     <pre class="idl">
       [
+        Exposed=Window,
         Constructor(DOMString type, optional ValueEventInit initDict),
         SecureContext
       ]
@@ -2230,8 +2232,8 @@ spec: promises-guide-1
     </p>
 
     <pre class="idl">
-      [SecureContext]
       interface BluetoothDevice {
+      [Exposed=Window, SecureContext]
         readonly attribute DOMString id;
         readonly attribute DOMString? name;
         readonly attribute BluetoothRemoteGATTServer? gatt;
@@ -2478,15 +2480,16 @@ spec: promises-guide-1
       </p>
 
       <pre class="idl">
-        [SecureContext]
+        [Exposed=Window, SecureContext]
         interface BluetoothManufacturerDataMap {
           readonly maplike&lt;unsigned short, DataView>;
         };
-        [SecureContext]
+        [Exposed=Window, SecureContext]
         interface BluetoothServiceDataMap {
           readonly maplike&lt;UUID, DataView>;
         };
         [
+          Exposed=Window,
           Constructor(DOMString type, BluetoothAdvertisingEventInit init),
           SecureContext
         ]
@@ -3168,7 +3171,7 @@ spec: promises-guide-1
     </p>
 
     <pre class="idl">
-      [SecureContext]
+      [Exposed=Window, SecureContext]
       interface BluetoothRemoteGATTServer {
         [SameObject]
         readonly attribute BluetoothDevice device;
@@ -3522,8 +3525,8 @@ spec: promises-guide-1
     </p>
 
     <pre class="idl">
-      [SecureContext]
       interface BluetoothRemoteGATTService {
+      [Exposed=Window, SecureContext]
         [SameObject]
         readonly attribute BluetoothDevice device;
         readonly attribute UUID uuid;
@@ -3687,8 +3690,8 @@ spec: promises-guide-1
     <p>{{BluetoothRemoteGATTCharacteristic}} represents a GATT <a>Characteristic</a>, which is a basic data element that provides further information about a peripheral's service.</p>
 
     <pre class="idl">
-      [SecureContext]
       interface BluetoothRemoteGATTCharacteristic {
+      [Exposed=Window, SecureContext]
         [SameObject]
         readonly attribute BluetoothRemoteGATTService service;
         readonly attribute UUID uuid;
@@ -4147,7 +4150,7 @@ spec: promises-guide-1
       </p>
 
       <pre class="idl">
-        [SecureContext]
+        [Exposed=Window, SecureContext]
         interface BluetoothCharacteristicProperties {
           readonly attribute boolean broadcast;
           readonly attribute boolean read;
@@ -4240,7 +4243,7 @@ spec: promises-guide-1
     <p>{{BluetoothRemoteGATTDescriptor}} represents a GATT <a>Descriptor</a>, which provides further information about a <a>Characteristic</a>'s value.</p>
 
     <pre class="idl">
-      [SecureContext]
+      [Exposed=Window, SecureContext]
       interface BluetoothRemoteGATTDescriptor {
         [SameObject]
         readonly attribute BluetoothRemoteGATTCharacteristic characteristic;
@@ -5164,6 +5167,7 @@ spec: promises-guide-1
     </p>
 
     <pre class="idl">
+      [Exposed=Window]
       interface BluetoothUUID {
         static UUID getService((DOMString or unsigned long) name);
         static UUID getCharacteristic((DOMString or unsigned long) name);


### PR DESCRIPTION
See https://github.com/heycam/webidl/pull/423 and https://github.com/heycam/webidl/pull/433 for more information.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/saschanaz/web-bluetooth/pull/415.html" title="Last updated on Nov 19, 2018, 12:31 AM GMT (b0e1340)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/415/ed01e98...saschanaz:b0e1340.html" title="Last updated on Nov 19, 2018, 12:31 AM GMT (b0e1340)">Diff</a>