### PR TITLE
Use actual type for Maps in BluetoothAdvertisingEventInit

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2512,8 +2512,8 @@ spec: promises-guide-1
           unsigned short appearance;
           byte txPower;
           byte rssi;
-          Map manufacturerData;
-          Map serviceData;
+          BluetoothManufacturerDataMap manufacturerData;
+          BluetoothServiceDataMap serviceData;
         };
       </pre>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dougt/web-bluetooth/pull/418.html" title="Last updated on Dec 10, 2018, 6:50 PM GMT (58a0752)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/418/742618d...dougt:58a0752.html" title="Last updated on Dec 10, 2018, 6:50 PM GMT (58a0752)">Diff</a>