### PR TITLE
Drop |name| attribute since it is accessible from the |device| attribute

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2496,7 +2496,6 @@ spec: promises-guide-1
           [SameObject]
           readonly attribute BluetoothDevice device;
           readonly attribute FrozenArray&lt;UUID> uuids;
-          readonly attribute DOMString? name;
           readonly attribute unsigned short? appearance;
           readonly attribute byte? txPower;
           readonly attribute byte? rssi;
@@ -2508,7 +2507,6 @@ spec: promises-guide-1
         dictionary BluetoothAdvertisingEventInit : EventInit {
           required BluetoothDevice device;
           sequence&lt;(DOMString or unsigned long)> uuids;
-          DOMString name;
           unsigned short appearance;
           byte txPower;
           byte rssi;


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dougt/web-bluetooth/pull/419.html" title="Last updated on Dec 10, 2018, 6:59 PM GMT (957ff9a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/419/742618d...dougt:957ff9a.html" title="Last updated on Dec 10, 2018, 6:59 PM GMT (957ff9a)">Diff</a>