### PR TITLE
This makes all but the device and uuids attributes optional

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2501,19 +2501,19 @@ spec: promises-guide-1
           readonly attribute byte? txPower;
           readonly attribute byte? rssi;
           [SameObject]
-          readonly attribute BluetoothManufacturerDataMap manufacturerData;
+          readonly attribute BluetoothManufacturerDataMap? manufacturerData;
           [SameObject]
-          readonly attribute BluetoothServiceDataMap serviceData;
+          readonly attribute BluetoothServiceDataMap? serviceData;
         };
         dictionary BluetoothAdvertisingEventInit : EventInit {
           required BluetoothDevice device;
           sequence&lt;(DOMString or unsigned long)> uuids;
-          DOMString name;
-          unsigned short appearance;
-          byte txPower;
-          byte rssi;
-          BluetoothManufacturerDataMap manufacturerData;
-          BluetoothServiceDataMap serviceData;
+          DOMString? name;
+          unsigned short? appearance;
+          byte? txPower;
+          byte? rssi;
+          BluetoothManufacturerDataMap? manufacturerData;
+          BluetoothServiceDataMap? serviceData;
         };
       </pre>
 


### PR DESCRIPTION
In both BluetoothAdvertisingEvent and BluetoothAdvertisingEventInit, there are a number of attributes that should be empty since underlying platform advertising events might not contain those fields.

I am not sure if uuids sequence should be optional.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dougt/web-bluetooth/pull/421.html" title="Last updated on Dec 13, 2018, 10:09 PM GMT (a3ed290)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/421/aaf7b68...dougt:a3ed290.html" title="Last updated on Dec 13, 2018, 10:09 PM GMT (a3ed290)">Diff</a>