### PR TITLE
Modify BluetoothLEScanOptions default values

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -195,8 +195,8 @@ spec:web-bluetooth
   <pre class="idl">
     dictionary BluetoothLEScanOptions {
       sequence&lt;BluetoothLEScanFilterInit> filters;
-      boolean keepRepeatedDevices = false;
-      boolean acceptAllAdvertisements = false;
+      boolean keepRepeatedDevices = true;
+      boolean acceptAllAdvertisements = true;
     };
 
     partial interface Bluetooth {


### PR DESCRIPTION
The default values of BluetoothLEScanOptions should be as if you didn't specify a filter to RequestLEScan().