### PR TITLE
Update example to not include |options| attribute

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -105,9 +105,7 @@ spec:web-bluetooth
             0x02, 0x15, // iBeacon identifier.
             0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15  // My beacon UUID.
           ])}}}],
-          options: {
-            keepRepeatedDevices: true,
-          }
+          keepRepeatedDevices: true
         }).then(() => {
           navigator.bluetooth.addEventListener('<a idl>advertisementreceived</a>', event => {
             let appleData = event.manufacturerData.get(<a


### PR DESCRIPTION
In Example 1, | keepRepeatedDevices| is inside |options|.  However, BluetoothLEScanOptions is defined as follows:

dictionary BluetoothLEScanOptions {
  sequence<BluetoothLEScanFilterInit> filters;
  boolean keepRepeatedDevices = false;
  boolean acceptAllAdvertisements = false;
};

So, we should strike |options| from the example.