### PR TITLE
Add 'onadvertisementreceived' attribute to BluetoothDeviceEventHandlers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4980,9 +4980,15 @@ spec: promises-guide-1
       <pre class="idl">
         [SecureContext]
         interface mixin BluetoothDeviceEventHandlers {
+          attribute EventHandler onadvertisementreceived;
           attribute EventHandler ongattserverdisconnected;
         };
       </pre>
+      <p>
+        <dfn attribute for="BluetoothDeviceEventHandlers">onadvertisementreceived</dfn>
+        is an <a>Event handler IDL attribute</a> for the
+        {{advertisementreceived}} event type.
+      </p>
       <p>
         <dfn attribute for="BluetoothDeviceEventHandlers">ongattserverdisconnected</dfn>
         is an <a>Event handler IDL attribute</a>


### PR DESCRIPTION
This event type was defined but the EventHandler attribute was missing
from the BluetoothDevice interface. This change adds it to the
BluetoothDeviceEventHandlers mixin so that it is also present on the
Bluetooth interface for bubbled events.

Fixes #426.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/reillyeon/web-bluetooth/pull/427.html" title="Last updated on Feb 12, 2019, 1:33 AM UTC (2c22fa0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/427/0c85d25...reillyeon:2c22fa0.html" title="Last updated on Feb 12, 2019, 1:33 AM UTC (2c22fa0)">Diff</a>