### PR TITLE
Clarify getAvailability for BT radio powered state

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -553,7 +553,8 @@ spec: promises-guide-1
 
     <p>
       <code>navigator.bluetooth.{{getAvailability()}}</code>
-      exposes whether a Bluetooth radio is available on the user's system.
+      exposes whether a Bluetooth radio is available on the user's system,
+      regardless of whether it is powered on or not.
       Some users might consider this private,
       although it's hard to imagine the damage that would result from revealing it.
       This information also increases the UA's <a>fingerprinting surface</a> by a bit.
@@ -2074,8 +2075,9 @@ spec: promises-guide-1
           and abort these steps.
         </li>
         <li>
-          If the UA has the ability to use Bluetooth,
-          <a>queue a task</a> to <a>resolve</a> |promise| with `true`.
+          If the UA is running on a system that has a Bluetooth radio
+          <a>queue a task</a> to <a>resolve</a> |promise| with `true` regardless
+          of the powered state of the Bluetooth radio.
         </li>
         <li>
           Otherwise, <a>queue a task</a> to <a>resolve</a> |promise| with `false`.


### PR DESCRIPTION
This change updates the Exposing Bluetooth availability and the
getAvailability() algorithm definition to explicitly mention that the
Bluetooth adapter powered state is not considered when determining the
availability.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/443.html" title="Last updated on Jun 14, 2019, 10:09 PM UTC (2d054ae)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/443/8c79d31...odejesush:2d054ae.html" title="Last updated on Jun 14, 2019, 10:09 PM UTC (2d054ae)">Diff</a>