### PR TITLE
index: fix the unneeded spaces at example lines

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -225,19 +225,14 @@ spec: webidl
             services: ['heart_rate'],
           }]
         }).then(device => device.gatt.<a for="BluetoothRemoteGATTServer">connect()</a>)
-        .then(server => server.<a idl for="BluetoothRemoteGATTServer" lt="getPrimaryService()">
-                              getPrimaryService</a>(<a idl lt="org.bluetooth.service.heart_rate">
-            'heart_rate'</a>))
+        .then(server => server.<a idl for="BluetoothRemoteGATTServer" lt="getPrimaryService()"
+          >getPrimaryService</a>(<a idl lt="org.bluetooth.service.heart_rate">'heart_rate'</a>))
         .then(service => {
           chosenHeartRateService = service;
           return Promise.all([
-            service.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()">
-                       getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.body_sensor_location">
-            'body_sensor_location'</a>)
+            service.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()">getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.body_sensor_location">'body_sensor_location'</a>)
               .then(handleBodySensorLocationCharacteristic),
-            service.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()">
-                       getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.heart_rate_measurement">
-            'heart_rate_measurement'</a>)
+            service.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()">getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.heart_rate_measurement">'heart_rate_measurement'</a>)
               .then(handleHeartRateMeasurementCharacteristic),
           ]);
         });
@@ -345,9 +340,7 @@ spec: webidl
           if (!chosenHeartRateService) {
             return Promise.reject(new Error('No heart rate sensor selected yet.'));
           }
-          return chosenHeartRateService.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()">
-                                         getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.heart_rate_control_point">
-            'heart_rate_control_point'</a>)
+          return chosenHeartRateService.<a idl for="BluetoothRemoteGATTService" lt="getCharacteristic()">getCharacteristic</a>(<a idl lt="org.bluetooth.characteristic.heart_rate_control_point">'heart_rate_control_point'</a>)
           .then(controlPoint => {
             let resetEnergyExpended = new Uint8Array([1]);
             return controlPoint.<a idl for="BluetoothRemoteGATTCharacteristic" lt="writeValue()">writeValue</a>(resetEnergyExpended);


### PR DESCRIPTION
Just fix the following format issue:

<img width="576" alt="Screen Shot 2019-10-23 at 8 27 06 PM" src="https://user-images.githubusercontent.com/1935767/67392670-8b91bf00-f5d3-11e9-82d4-af95e46d8933.png">


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/yorkie/web-bluetooth/pull/457.html" title="Last updated on Oct 23, 2019, 12:28 PM UTC (142c9c2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/457/720be21...yorkie:142c9c2.html" title="Last updated on Oct 23, 2019, 12:28 PM UTC (142c9c2)">Diff</a>