### PR TITLE
Clarify availability permission relationship

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2073,7 +2073,7 @@ spec: webidl
           and abort these steps.
 
           Note: If the Web Bluetooth permission has been blocked by the user,
-          the UA may resolve the promise with false here.
+          the UA may <a>resolve</a> |promise| with  `false`.
         </li>
         <li>
           If the UA is running on a system that has a Bluetooth radio

--- a/index.bs
+++ b/index.bs
@@ -2093,24 +2093,27 @@ spec: webidl
     <div class="example" id="example-getAvailability-PermissionStatus-onchange">
       <p>If the user has blocked the permission and the UA resolves the
       <code><a idl>getAvailability</a></code> promise with false, the following can be used to detect
-      when Bluetooth is available again:</p>
+      when Bluetooth is available again to show Bluetooth UI:</p>
       <pre highlight="js">
-      // Check if Bluetooth is available first.
-      navigator.bluetooth.getAvailability().then(isAvailable => {
-        if (!isAvailable) {
-          // Check if the permission has been blocked
-          navigator.permission.query({name: "bluetooth"}).then(status => {
-            if (status.state === 'denied') {
-              // Bluetooth is blocked, listen for change in PermissionStatus.
-              status.onchange = () => {
-                if (this.state == 'prompt') {
-                  // Bluetooth is available now.
-                }
-              };
-            }
-          });
+      function checkAvailability() {
+        const BluetoothUI = document.querySelector('#bluetoothUI');
+        navigator.bluetooth.<a idl>getAvailability()</a>.then(isAvailable => {
+          bluetoothUI.hidden = !isAvailable;
+        });
+      }
+
+      navigator.permission.query({name: "bluetooth"}).then(status => {
+        if (status.state !== 'denied') {
+          checkAvailability();
+          return;
         }
+
+        // Bluetooth is blocked, listen for change in PermissionStatus.
+        status.onchange = () => {
+          if (this.state !== 'denied') checkAvailability();
+        };
       });
+      </pre>
     </div>
 
     <div algorithm="availabilitychanged" id="availability-changed-algorithm"

--- a/index.bs
+++ b/index.bs
@@ -2096,17 +2096,14 @@ spec: webidl
       when Bluetooth is available again to show Bluetooth UI:</p>
       <pre highlight="js">
       function checkAvailability() {
-        const BluetoothUI = document.querySelector('#bluetoothUI');
+        const bluetoothUI = document.querySelector('#bluetoothUI');
         navigator.bluetooth.<a idl>getAvailability()</a>.then(isAvailable => {
           bluetoothUI.hidden = !isAvailable;
         });
       }
 
       navigator.permission.query({name: "bluetooth"}).then(status => {
-        if (status.state !== 'denied') {
-          checkAvailability();
-          return;
-        }
+        if (status.state !== 'denied') checkAvailability();
 
         // Bluetooth is blocked, listen for change in PermissionStatus.
         status.onchange = () => {

--- a/index.bs
+++ b/index.bs
@@ -551,7 +551,8 @@ spec: webidl
     <p>
       <code>navigator.bluetooth.{{getAvailability()}}</code>
       exposes whether a Bluetooth radio is available on the user's system,
-      regardless of whether it is powered on or not.
+      regardless of whether it is powered on or not. The availability is also
+      affected if the user has configured the UA to block Web Bluetooth.
       Some users might consider this private,
       although it's hard to imagine the damage that would result from revealing it.
       This information also increases the UA's <a>fingerprinting surface</a> by a bit.
@@ -2033,7 +2034,7 @@ spec: webidl
     </dl>
   </section>
 
-  <section class="unstable">
+  <section>
     <h3 id="availability">Overall Bluetooth availability</h3>
 
     <p>
@@ -2070,6 +2071,9 @@ spec: webidl
           return a particular answer from this function for the current origin,
           <a>queue a task</a> to <a>resolve</a> |promise| with the configured answer,
           and abort these steps.
+
+          Note: If the Web Bluetooth permission has been blocked by the user,
+          the UA may resolve the promise with false here.
         </li>
         <li>
           If the UA is running on a system that has a Bluetooth radio
@@ -2081,12 +2085,36 @@ spec: webidl
         </li>
       </ol>
 
-      Note: the promise is resolved <a>in parallel</a>
+      Note: The promise is resolved <a>in parallel</a>
       to let the UA call out to other systems
       to determine whether Bluetooth is available.
     </div>
 
-    <div algorithm="availabilitychanged" id="availability-changed-algorithm">
+    <div class="example" id="example-getAvailability-PermissionStatus-onchange">
+      <p>If the user has blocked the permission and the UA resolves the
+      <code><a idl>getAvailability</a></code> promise with false, the following can be used to detect
+      when Bluetooth is available again:</p>
+      <pre highlight="js">
+      // Check if Bluetooth is available first.
+      navigator.bluetooth.getAvailability().then(isAvailable => {
+        if (!isAvailable) {
+          // Check if the permission has been blocked
+          navigator.permission.query({name: "bluetooth"}).then(status => {
+            if (status.state === 'denied') {
+              // Bluetooth is blocked, listen for change in PermissionStatus.
+              status.onchange = () => {
+                if (this.state == 'prompt') {
+                  // Bluetooth is available now.
+                }
+              };
+            }
+          });
+        }
+      });
+    </div>
+
+    <div algorithm="availabilitychanged" id="availability-changed-algorithm"
+        class="unstable">
       <p>
         If the UA becomes able or unable to use Bluetooth,
         for example because a radio was physically attached or detached,


### PR DESCRIPTION
Add details on the interaction between the Bluetooth availability and Bluetooth permission. This should help to resolve some of the confusion brought up in #459.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/461.html" title="Last updated on Nov 4, 2019, 10:28 PM UTC (9153fa2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/461/5f57c59...odejesush:9153fa2.html" title="Last updated on Nov 4, 2019, 10:28 PM UTC (9153fa2)">Diff</a>