### PR TITLE
Update language for User Activation v2

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1270,8 +1270,11 @@ spec: webidl
     </p>
     <ol>
       <li id="requestDevice-user-gesture">
-        If the algorithm is not <a>triggered by user activation</a>,
-        throw a {{SecurityError}} and abort these steps.
+        Check that the algorithm is triggered while its [=relevant global
+        object=] has a <a
+        href="https://html.spec.whatwg.org/#tracking-user-activation"> transient
+        activation</a>, otherwise throw a {{SecurityError}} and abort these
+        steps.
       </li>
       <li>
         In order to convert the arguments from service names and aliases to just <a>UUID</a>s,

--- a/scanning.bs
+++ b/scanning.bs
@@ -209,9 +209,11 @@ spec:web-bluetooth
       asking the user for permission if they haven't yet granted it.
     </p>
     <p>
-      Because this could show a prompt,
-      it requires a <a>secure context</a>,
-      and UAs are likely to require a <a lt="triggered by user activation">user gesture</a>.
+      Because this could show a prompt, it requires a <a>secure context</a>.
+      Additionally, UAs are likely to require a <a
+      href="https://html.spec.whatwg.org/#tracking-user-activation"> transient
+      user activation</a> on its [=relevant global object=] when
+      {{requestLEScan}} is called.
     </p>
     <p>
       Advertising events that <a for="BluetoothLEScanFilter">match</a>
@@ -276,7 +278,9 @@ spec:web-bluetooth
           }
         </pre>
 
-        Note: This may require that this algorithm was <a>triggered by user activation</a>.
+        Note: This may require that this algorithm has a <a
+        href="https://html.spec.whatwg.org/#tracking-user-activation"> transient
+        activation</a> on its [=relevant global object=] when triggered.
       </li>
       <li>
         If the result is {{"denied"}},


### PR DESCRIPTION
This change updates the "request Bluetooth devices" algorithm to refer
to the User Activation v2 model. The algorithm now has to be triggered
while its relevant global object has a transient activation before being
allowed to continue.

This fixes #463.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/470.html" title="Last updated on Feb 11, 2020, 7:08 PM UTC (2336d55)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/470/9991588...odejesush:2336d55.html" title="Last updated on Feb 11, 2020, 7:08 PM UTC (2336d55)">Diff</a>