### PR TITLE
Use Markdown for Section 4

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1826,658 +1826,507 @@ it was initialized to.
   Such a generic event type belongs in [[HTML]] or [[DOM]], not here.
 </div>
 
-<section>
-  <h2 id="device-representation">Device Representation</h2>
+# Device Representation # {#device-representation}
 
-  <p>
-    The UA needs to track Bluetooth device properties at several levels:
-    globally, per origin, and per <a>global object</a>.
-  </p>
+The UA needs to track Bluetooth device properties at several levels: globally,
+per origin, and per <a>global object</a>.
 
-  <section>
-    <h3 id="global-device-properties">Global Bluetooth device properties</h3>
+## Global Bluetooth device properties ## {#global-device-properties}
 
-    <p>
-      The physical Bluetooth device may be guaranteed to have
-      some properties that the UA may not have received.
-      Those properties are described as optional here.
-    </p>
+The physical Bluetooth device may be guaranteed to have some properties that the
+UA may not have received. Those properties are described as optional here.
 
-    <p>
-      A <dfn export>Bluetooth device</dfn> has the following properties.
-      Optional properties are not present, and sequence and map properties are empty,
-      unless/until described otherwise.
-      Other properties have a default specified or are specified when a device is introduced.
-    </p>
+A <dfn export>Bluetooth device</dfn> has the following properties. Optional
+properties are not present, and sequence and map properties are empty,
+unless/until described otherwise. Other properties have a default specified or
+are specified when a device is introduced.
 
-    <ul>
-      <li>
-        A set of <dfn>supported physical transports</dfn>,
-        including one or both of BR/EDR and LE.
-        This set will generally be filled based on
-        the transports over which the device was discovered
-        and the <a>Flags Data Type</a>
-        in the <a>Advertising Data</a> or <a>Extended Inquiry Response</a>.
-      </li>
-      <li>
-        One or more of several kinds of 48-bit address:
-        a <a>Public Bluetooth Address</a>, a (random) <a>Static Address</a>,
-        and a resolvable or non-resolvable <a>Private Address</a>.
-      </li>
-      <li>An optional 128-bit <a>Identity Resolving Key</a>.</li>
+* A set of <dfn>supported physical transports</dfn>, including one or both of
+    BR/EDR and LE. This set will generally be filled based on the transports
+    over which the device was discovered and the <a>Flags Data Type</a> in the
+    <a>Advertising Data</a> or <a>Extended Inquiry Response</a>.
+* One or more of several kinds of 48-bit address: a <a>Public Bluetooth
+    Address</a>, a (random) <a>Static Address</a>, and a resolvable or
+    non-resolvable <a>Private Address</a>.
+* An optional 128-bit <a>Identity Resolving Key</a>.
+* An optional partial or complete <a>Bluetooth Device Name</a>. A device has a
+    partial name when the <a>Shortened Local Name</a> AD data was received, but
+    the full name hasn't been read yet. The <a>Bluetooth Device Name</a> is
+    encoded as UTF-8 and converted to a DOMString using the <a>utf-8 decode
+    without BOM</a> algorithm.
+* An optional <a>ATT Bearer</a>, over which all GATT communication happens. The
+    <a>ATT Bearer</a> is created by procedures described in "Connection
+    Establishment" under <a>GAP Interoperability Requirements</a>. It is
+    disconnected in ways [[BLUETOOTH42]] isn't entirely clear about.
+* A list of advertised <a>Service UUIDs</a> from the <a>Advertising Data</a> or
+    <a>Extended Inquiry Response</a>.
+* A hierarchy of GATT <a>Attributes</a>.
 
-      <li>
-        An optional partial or complete <a>Bluetooth Device Name</a>.
-        A device has a partial name when the <a>Shortened Local Name</a> AD data was received,
-        but the full name hasn't been read yet.
-        The <a>Bluetooth Device Name</a> is encoded as UTF-8 and
-        converted to a DOMString using the <a>utf-8 decode without BOM</a> algorithm.
-      </li>
+The UA SHOULD determine that two <a>Bluetooth device</a>s are the <dfn export
+local-lt="same device">same Bluetooth device</dfn> if and only if they have the
+same <a>Public Bluetooth Address</a>, <a>Static Address</a>, <a>Private
+Address</a>, or <a>Identity Resolving Key</a>, or if the <a>Resolvable Private
+Address Resolution Procedure</a> succeeds using one device's IRK and the other's
+Resolvable <a>Private Address</a>. However, because platform APIs don't document
+how they determine device identity, the UA MAY use another procedure.
 
-      <li>
-        An optional <a>ATT Bearer</a>, over which all GATT communication happens.
-        The <a>ATT Bearer</a> is created by procedures described in
-        "Connection Establishment" under <a>GAP Interoperability Requirements</a>.
-        It is disconnected in ways [[BLUETOOTH42]] isn't entirely clear about.
-      </li>
+## BluetoothDevice ## {#bluetoothdevice-interface}
 
-      <li>
-        A list of advertised <a>Service UUIDs</a>
-        from the <a>Advertising Data</a> or <a>Extended Inquiry Response</a>.
-      </li>
+A {{BluetoothDevice}} instance represents a <a>Bluetooth device</a> for a
+particular <a>global object</a> (or, equivalently, for a particular <a>Realm</a>
+or {{Bluetooth}} instance).
 
-      <li>
-        A hierarchy of GATT <a>Attributes</a>.
-      </li>
-    </ul>
+<xmp class="idl">
+  [Exposed=Window, SecureContext]
+  interface BluetoothDevice : EventTarget {
+    readonly attribute DOMString id;
+    readonly attribute DOMString? name;
+    readonly attribute BluetoothRemoteGATTServer? gatt;
 
-    <p>
-      The UA SHOULD determine that
-      two <a>Bluetooth device</a>s are
-      the <dfn export local-lt="same device">same Bluetooth device</dfn> if and only if
-      they have the same <a>Public Bluetooth Address</a>, <a>Static Address</a>,
-      <a>Private Address</a>, or <a>Identity Resolving Key</a>,
-      or if the <a>Resolvable Private Address Resolution Procedure</a> succeeds using
-      one device's IRK and the other's Resolvable <a>Private Address</a>.
-      However, because platform APIs don't document how they determine device identity,
-      the UA MAY use another procedure.
-    </p>
-  </section>
+    Promise<void> watchAdvertisements();
+    void unwatchAdvertisements();
+    readonly attribute boolean watchingAdvertisements;
+  };
+  BluetoothDevice includes BluetoothDeviceEventHandlers;
+  BluetoothDevice includes CharacteristicEventHandlers;
+  BluetoothDevice includes ServiceEventHandlers;
+</xmp>
 
-  <section>
-    <h3 id="bluetoothdevice" dfn-type="interface">BluetoothDevice</h3>
+<div class="note" heading="{{BluetoothDevice}} attributes"
+dfn-for="BluetoothDevice" dfn-type="attribute">
+<dfn>id</dfn> uniquely identifies a device to the extent that the UA can
+determine that two Bluetooth connections are to the same device and to the
+extent that the user <a href="#note-device-id-tracking">wants to expose that
+fact to script</a>.
 
-    <p>
-      A {{BluetoothDevice}} instance represents a <a>Bluetooth device</a>
-      for a particular <a>global object</a>
-      (or, equivalently, for a particular <a>Realm</a> or {{Bluetooth}} instance).
-    </p>
+<dfn>name</dfn> is the human-readable name of the device.
 
-    <pre class="idl">
-      [Exposed=Window, SecureContext]
-      interface BluetoothDevice : EventTarget {
-        readonly attribute DOMString id;
-        readonly attribute DOMString? name;
-        readonly attribute BluetoothRemoteGATTServer? gatt;
+{{BluetoothDevice/gatt}} provides a way to interact with this device's GATT
+server if the site has permission to do so.
 
-        Promise&lt;void> watchAdvertisements();
-        void unwatchAdvertisements();
-        readonly attribute boolean watchingAdvertisements;
-      };
-      BluetoothDevice includes BluetoothDeviceEventHandlers;
-      BluetoothDevice includes CharacteristicEventHandlers;
-      BluetoothDevice includes ServiceEventHandlers;
+<dfn>watchingAdvertisements</dfn> is true if the UA is currently scanning for
+advertisements from this device and firing events for them.
+</div>
+
+Instances of {{BluetoothDevice}} are created with the <a>internal slots</a>
+described in the following table:
+
+<table dfn-for="BluetoothDevice" dfn-type="attribute">
+  <tr>
+    <th><a>Internal Slot</a></th>
+    <th>Initial Value</th>
+    <th>Description (non-normative)</th>
+  </tr>
+  <tr>
+    <td><dfn>\[[context]]</dfn></td>
+    <td>&lt;always set in prose></td>
+    <td>
+      The {{Bluetooth}} object that returned this {{BluetoothDevice}}.
+    </td>
+  </tr>
+  <tr>
+    <td><dfn>\[[representedDevice]]</dfn></td>
+    <td>&lt;always set in prose></td>
+    <td>
+      The <a>Bluetooth device</a> this object represents,
+      or `null` if access has been <a lt="revoke Bluetooth access">revoked</a>.
+    </td>
+  </tr>
+  <tr>
+    <td><dfn>\[[gatt]]</dfn></td>
+    <td>
+      a new {{BluetoothRemoteGATTServer}} instance with its
+      {{BluetoothRemoteGATTServer/device}} attribute initialized to `this` and
+      its {{BluetoothRemoteGATTServer/connected}} attribute initialized to
+      `false`.
+    </td>
+    <td>
+      Does not change.
+    </td>
+  </tr>
+  <tr>
+    <td><dfn>\[[allowedServices]]</dfn></td>
+    <td>&lt;always set in prose></td>
+    <td>
+      This device's {{AllowedBluetoothDevice/allowedServices}} list for this
+      origin or `"all"` if all services are allowed. For example, a UA may grant
+      an origin access to all services on a {{referringDevice}} that advertised
+      a URL on that origin.
+    </td>
+  </tr>
+</table>
+
+<div algorithm="get or create BluetoothDevice">
+To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
+<a>Bluetooth device</a> <var>device</var> inside a {{Bluetooth}} instance
+<var>context</var>, the UA MUST run the following steps:
+
+1. Let |data|, a {{BluetoothPermissionData}}, be {{"bluetooth"}}'s <a>extra
+    permission data</a> for the <a>current settings object</a>.
+1. Find the |allowedDevice| in <code>|data|.{{allowedDevices}}</code> with
+    <code><var>allowedDevice</var>.{{[[device]]}}</code> the <a>same device</a>
+    as <var>device</var>. If there is no such object, throw a {{SecurityError}}
+    and abort these steps.
+1. If there is no key in <var>context</var>.{{Bluetooth/[[deviceInstanceMap]]}}
+    that is the <a>same device</a> as <var>device</var>, run the following
+    sub-steps:
+    1. Let <var>result</var> be a new instance of {{BluetoothDevice}}.
+    1. Initialize all of <var>result</var>'s optional fields to
+        <code>null</code>.
+    1. Initialize <code><var>result</var>.{{[[context]]}}</code> to
+        <var>context</var>.
+    1. Initialize <code><var>result</var>.{{[[representedDevice]]}}</code> to
+        <var>device</var>.
+    1. Initialize <code><var>result</var>.id</code> to
+        <code><var>allowedDevice</var>.{{AllowedBluetoothDevice/deviceId}}</code>,
+        and initialize
+        <code><var>result</var>.{{BluetoothDevice/[[allowedServices]]}}</code>
+        to <code><var>allowedDevice</var>.{{allowedServices}}</code>.
+    1. If <var>device</var> has a partial or complete <a>Bluetooth Device
+        Name</a>, set <code><var>result</var>.name</code> to that string.
+    1. Initialize <code><var>result</var>.watchingAdvertisements</code> to
+        `false`.
+    1. Add a mapping from <var>device</var> to <var>result</var> in
+        <var>context</var>.{{Bluetooth/[[deviceInstanceMap]]}}.
+1. Return the value in <var>context</var>.{{Bluetooth/[[deviceInstanceMap]]}}
+    whose key is the <a>same device</a> as <var>device</var>.
+
+</div>
+
+<div algorithm="get gatt attribute">
+Getting the <code><dfn attribute for="BluetoothDevice">gatt</dfn></code>
+attribute MUST perform the following steps:
+
+1. If {{"bluetooth"}}'s <a>extra permission data</a> for `this`'s <a>relevant
+    settings object</a> has an {{AllowedBluetoothDevice}} |allowedDevice| in its
+    {{BluetoothPermissionData/allowedDevices}} list with
+    <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code> the
+    <a>same device</a> as <code>this.{{[[representedDevice]]}}</code> and
+    <code>|allowedDevice|.{{AllowedBluetoothDevice/mayUseGATT}}</code> equal to
+    `true`, return <code>this.{{[[gatt]]}}</code>.
+1. Otherwise, return `null`.
+
+</div>
+
+<div algorithm="watchAdvertisements" class="unstable">
+The <code><dfn method for="BluetoothDevice">watchAdvertisements()</dfn></code>
+method, when invoked, MUST return <a>a new promise</a> |promise| and run the
+following steps <a>in parallel</a>:
+
+1. Ensure that the UA is scanning for this device's advertisements. The UA
+    SHOULD NOT filter out "duplicate" advertisements for the same device.
+1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of the
+    following errors, and abort these steps:
+
+    <dl class="switch">
+      <dt>The UA doesn't support scanning for advertisements</dt>
+      <dd>{{NotSupportedError}}</dd>
+
+      <dt>Bluetooth is turned off</dt>
+      <dd>{{InvalidStateError}}</dd>
+
+      <dt>Other reasons</dt>
+      <dd>{{UnknownError}}</dd>
+    </dl>
+1. <a>Queue a task</a> to perform the following steps:
+    1. Set <code>this.{{watchingAdvertisements}}</code> to `true`.
+    1. Resolve |promise| with `undefined`.
+
+<div class="note">
+Scanning costs power, so websites should avoid watching for advertisements
+unnecessarily, and should call {{unwatchAdvertisements()}} to stop using power
+as soon as possible.
+</div>
+</div>
+
+<div algorithm="unwatchAdvertisements" class="unstable">
+The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code>
+method, when invoked, MUST run the following steps:
+
+1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
+1. If no more {{BluetoothDevice}}s in the whole UA have
+    {{watchingAdvertisements}} set to `true`, the UA SHOULD stop scanning for
+    advertisements. Otherwise, if no more {{BluetoothDevice}}s representing the
+    same device as `this` have {{watchingAdvertisements}} set to `true`, the UA
+    SHOULD reconfigure the scan to avoid receiving reports for this device.
+
+</div>
+
+<div class="unstable">
+### Responding to Advertising Events ### {#advertising-events}
+
+When an <a>advertising event</a> arrives for a {{BluetoothDevice}}
+with {{BluetoothDevice/watchingAdvertisements}} set,
+the UA delivers an "{{advertisementreceived}}" event.
+
+<xmp class="idl">
+  [Exposed=Window, SecureContext]
+  interface BluetoothManufacturerDataMap {
+    readonly maplike<unsigned short, DataView>;
+  };
+  [Exposed=Window, SecureContext]
+  interface BluetoothServiceDataMap {
+    readonly maplike<UUID, DataView>;
+  };
+  [
+    Exposed=Window,
+    SecureContext
+  ]
+  interface BluetoothAdvertisingEvent : Event {
+    constructor(DOMString type, BluetoothAdvertisingEventInit init);
+    [SameObject]
+    readonly attribute BluetoothDevice device;
+    readonly attribute FrozenArray<UUID> uuids;
+    readonly attribute DOMString? name;
+    readonly attribute unsigned short? appearance;
+    readonly attribute byte? txPower;
+    readonly attribute byte? rssi;
+    [SameObject]
+    readonly attribute BluetoothManufacturerDataMap manufacturerData;
+    [SameObject]
+    readonly attribute BluetoothServiceDataMap serviceData;
+  };
+  dictionary BluetoothAdvertisingEventInit : EventInit {
+    required BluetoothDevice device;
+    sequence<(DOMString or unsigned long)> uuids;
+    DOMString name;
+    unsigned short appearance;
+    byte txPower;
+    byte rssi;
+    BluetoothManufacturerDataMap manufacturerData;
+    BluetoothServiceDataMap serviceData;
+  };
+</xmp>
+
+<div class="note" heading="{{BluetoothAdvertisingEvent}} attributes"
+  dfn-for="BluetoothAdvertisingEvent" dfn-type="attribute"
+  link-for-hint="BluetoothAdvertisingEvent">
+<dfn>device</dfn> is the {{BluetoothDevice}} that sent this advertisement.
+
+<dfn>uuids</dfn> lists the Service UUIDs that this advertisement says
+{{device}}'s GATT server supports.
+
+<dfn>name</dfn> is {{device}}'s local name, or a prefix of it.
+
+<dfn>appearance</dfn> is an <a>Appearance</a>, one of the values defined by the
+{{org.bluetooth.characteristic.gap.appearance}} characteristic.
+
+<dfn>txPower</dfn> is the transmission power at which the device is
+broadcasting, measured in dBm. This is used to compute the path loss as
+<code>this.txPower - this.rssi</code>.
+
+<dfn>rssi</dfn> is the power at which the advertisement was received, measured
+in dBm. This is used to compute the path loss as <code>this.txPower -
+this.rssi</code>.
+
+<dfn>manufacturerData</dfn> maps <code>unsigned short</code> Company Identifier
+Codes to {{DataView}}s.
+
+<dfn>serviceData</dfn> maps {{UUID}}s to {{DataView}}s.
+</div>
+
+<div class="example" id="example-interpret-ibeacon">
+To retrieve a device and read the iBeacon data out of it, a developer could use
+the following code. Note that this API currently doesn't provide a way to
+request devices with certain manufacturer data, so the iBeacon will need to
+rotate its advertisements to include a known service in order for users to
+select this device in the <code>requestDevice</code> dialog.
+
+<pre highlight="js">
+  var known_service = "A service in the iBeacon's GATT server";
+  return navigator.bluetooth.requestDevice({
+    filters: [{services: [known_service]}]
+  }).then(device => {
+    device.watchAdvertisements();
+    device.addEventListener('advertisementreceived', interpretIBeacon);
+  });
+
+  function interpretIBeacon(event) {
+    var rssi = event.rssi;
+    var appleData = event.manufacturerData.get(<a
+        href="https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers"
+        title="Apple, Inc.'s Company Identifier">0x004C</a>);
+    if (appleData.byteLength != 23 ||
+      appleData.getUint16(0, false) !== 0x0215) {
+      console.log({isBeacon: false});
+    }
+    var uuidArray = new Uint8Array(appleData.buffer, 2, 16);
+    var major = appleData.getUint16(18, false);
+    var minor = appleData.getUint16(20, false);
+    var txPowerAt1m = -appleData.getInt8(22);
+    console.log({
+        isBeacon: true,
+        uuidArray,
+        major,
+        minor,
+        pathLossVs1m: txPowerAt1m - rssi});
+  });
+</pre>
+
+The format of iBeacon advertisements was derived from <a
+href="http://www.warski.org/blog/2014/01/how-ibeacons-work/">How do iBeacons
+work?</a> by Adam Warski.
+</div>
+
+<div algorithm="received advertising event" id="advertising-event-algorithm">
+When the UA receives an <a>advertising event</a> (consisting of an advertising
+packet and an optional scan response), it MUST run the following steps:
+
+1. Let <var>device</var> be the <a>Bluetooth device</a> that sent the
+    advertising event.
+1. For each {{BluetoothDevice}} <var>deviceObj</var> in the UA such that
+    <var>device</var> is the <a>same device</a> as
+    <code><var>deviceObj</var>.{{[[representedDevice]]}}</code>, <a>queue a
+    task</a> on <var>deviceObj</var>'s <a>relevant settings object</a>'s
+    <a>responsible event loop</a> to do the following sub-steps:
+    1. If <code><var>deviceObj</var>.{{watchingAdvertisements}}</code> is
+        `false`, abort these sub-steps.
+    1. <a>Fire an `advertisementreceived` event</a> for the advertising event at
+        |deviceObj|.
+
+</div>
+
+<div algorithm="fire advertisementreceived event">
+To <dfn export>fire an {{advertisementreceived}} event</dfn>
+for an advertising event |adv| at a {{BluetoothDevice}} |deviceObj|,
+the UA MUST perform the following steps:
+
+1. Let <var>event</var> be
+    <pre highlight="js">
+      {
+        bubbles: true,
+        device: <var>deviceObj</var>,
+        uuids: [],
+        manufacturerData: new Map(),
+        serviceData: new Map()
+      }
     </pre>
 
-    <div class="note" heading="{{BluetoothDevice}} attributes"
-         dfn-for="BluetoothDevice" dfn-type="attribute">
-      <p>
-        <dfn>id</dfn> uniquely identifies a device to the extent that
-        the UA can determine that two Bluetooth connections are to the same device
-        and to the extent that
-        the user <a href="#note-device-id-tracking">wants to expose that fact to script</a>.
-      </p>
+1. If the <a>received signal strength</a> is available for any packet in |adv|,
+    set <code><var>event</var>.rssi</code> to this signal strength in dBm.
 
-      <p>
-        <dfn>name</dfn> is the human-readable name of the device.
-      </p>
+1. For each <a>AD structure</a> in |adv|'s advertising packet and scan response,
+    select from the following steps depending on the AD type:
 
-      <p>
-        {{BluetoothDevice/gatt}} provides a way to interact with this device's GATT server
-        if the site has permission to do so.
-      </p>
+    <dl class="switch">
+      <dt>
+        Incomplete List of 16-bit <a lt="Service UUID Data Type">Service
+        UUIDs</a>
+      </dt>
+      <dt>
+        Complete List of 16-bit <a lt="Service UUID Data Type">Service UUIDs</a>
+      </dt>
+      <dt>
+        Incomplete List of 32-bit <a lt="Service UUID Data Type">Service
+        UUIDs</a>
+      </dt>
+      <dt>
+        Complete List of 32-bit <a lt="Service UUID Data Type">Service UUIDs</a>
+      </dt>
+      <dt>
+        Incomplete List of 128-bit <a lt="Service UUID Data Type">Service
+        UUIDs</a>
+      </dt>
+      <dt>
+        Complete List of 128-bit <a lt="Service UUID Data Type">Service
+        UUIDs</a>
+      </dt>
+      <dd>
+        Append the listed UUIDs to <code><var>event</var>.uuids</code>.
+      </dd>
 
-      <p>
-        <dfn>watchingAdvertisements</dfn> is true if
-        the UA is currently scanning for advertisements from this device
-        and firing events for them.
-      </p>
-    </div>
+      <dt>Shortened <a lt="Local Name Data Type">Local Name</a></dt>
+      <dt>Complete <a lt="Local Name Data Type">Local Name</a></dt>
+      <dd>
+        <a>UTF-8 decode without BOM</a> the AD data and set
+        <code><var>event</var>.name</code> to the result.
 
-    <p>
-      Instances of {{BluetoothDevice}} are created with the <a>internal slots</a>
-      described in the following table:
-    </p>
-    <table class="data" dfn-for="BluetoothDevice" dfn-type="attribute">
-      <thead>
-        <th><a>Internal Slot</a></th>
-        <th>Initial Value</th>
-        <th>Description (non-normative)</th>
-      </thead>
-      <tr>
-        <td><dfn>\[[context]]</dfn></td>
-        <td>&lt;always set in prose></td>
-        <td>
-          The {{Bluetooth}} object that returned this {{BluetoothDevice}}.
-        </td>
-      </tr>
-      <tr>
-        <td><dfn>\[[representedDevice]]</dfn></td>
-        <td>&lt;always set in prose></td>
-        <td>
-          The <a>Bluetooth device</a> this object represents,
-          or `null` if access has been <a lt="revoke Bluetooth access">revoked</a>.
-        </td>
-      </tr>
-      <tr>
-        <td><dfn>\[[gatt]]</dfn></td>
-        <td>
-          a new {{BluetoothRemoteGATTServer}} instance with
-          its {{BluetoothRemoteGATTServer/device}} attribute initialized to `this`
-          and its {{BluetoothRemoteGATTServer/connected}} attribute initialized to `false`.
-        </td>
-        <td>
-          Does not change.
-        </td>
-      </tr>
-      <tr>
-        <td><dfn>\[[allowedServices]]</dfn></td>
-        <td>&lt;always set in prose></td>
-        <td>
-          This device's {{AllowedBluetoothDevice/allowedServices}} list for this origin
-          or `"all"` if all services are allowed.
-          For example, a UA may grant an origin access to all services on
-          a {{referringDevice}} that advertised a URL on that origin.
-        </td>
-      </tr>
-    </table>
+        <div class="note">
+          Note: We don't expose whether the name is complete because existing
+          APIs require reading the raw advertisement to get this information,
+          and we want more evidence that it's useful before adding a field to
+          the API.
+        </div>
+      </dd>
 
-    <div algorithm>
-      <p>
-        To <dfn export>get the <code>BluetoothDevice</code> representing</dfn>
-        a <a>Bluetooth device</a> <var>device</var>
-        inside a {{Bluetooth}} instance <var>context</var>,
-        the UA MUST run the following steps:
-      </p>
-      <ol>
-        <li>
-          Let |data|, a {{BluetoothPermissionData}},
-          be {{"bluetooth"}}'s <a>extra permission data</a>
-          for the <a>current settings object</a>.
-        </li>
-        <li>
-          Find the |allowedDevice| in <code>|data|.{{allowedDevices}}</code>
-          with <code><var>allowedDevice</var>.{{[[device]]}}</code>
-          the <a>same device</a> as <var>device</var>.
-          If there is no such object,
-          throw a {{SecurityError}} and abort these steps.
-        </li>
-        <li>
-          If there is no key in
-          <var>context</var>.{{Bluetooth/[[deviceInstanceMap]]}}
-          that is the <a>same device</a> as <var>device</var>,
-          run the following sub-steps:
-          <ol>
-            <li>Let <var>result</var> be a new instance of {{BluetoothDevice}}.</li>
-            <li>Initialize all of <var>result</var>'s optional fields to <code>null</code>.</li>
-            <li>
-              Initialize <code><var>result</var>.{{[[context]]}}</code>
-              to <var>context</var>.
-            </li>
-            <li>
-              Initialize <code><var>result</var>.{{[[representedDevice]]}}</code>
-              to <var>device</var>.
-            </li>
-            <li>
-              Initialize <code><var>result</var>.id</code>
-              to <code><var>allowedDevice</var>.{{AllowedBluetoothDevice/deviceId}}</code>,
-              and initialize <code><var>result</var>.{{BluetoothDevice/[[allowedServices]]}}</code>
-              to <code><var>allowedDevice</var>.{{allowedServices}}</code>.
-            </li>
-            <li>
-              If <var>device</var> has a partial or complete <a>Bluetooth Device Name</a>,
-              set <code><var>result</var>.name</code> to that string.
-            </li>
-            <li>
-              Initialize <code><var>result</var>.watchingAdvertisements</code> to `false`.
-            </li>
-            <li>
-              Add a mapping from <var>device</var> to <var>result</var>
-              in <var>context</var>.{{Bluetooth/[[deviceInstanceMap]]}}.
-            </li>
-          </ol>
-        </li>
-        <li>
-          Return the value in
-          <var>context</var>.{{Bluetooth/[[deviceInstanceMap]]}}
-          whose key is the <a>same device</a> as <var>device</var>.
-        </li>
-      </ol>
-    </div>
+      <dt><a>Manufacturer Specific Data</a></dt>
+      <dd>
+        Add to <code><var>event</var>.manufacturerData</code> a mapping from the
+        16-bit Company Identifier Code to an {{ArrayBuffer}} containing the
+        manufacturer-specific data.
+      </dd>
 
-    <div algorithm>
-      <p>
-        Getting the <code><dfn attribute for="BluetoothDevice">gatt</dfn></code> attribute
-        MUST perform the following steps:
-      </p>
-      <ol>
-        <li>
-          If {{"bluetooth"}}'s <a>extra permission data</a>
-          for `this`'s <a>relevant settings object</a>
-          has an {{AllowedBluetoothDevice}} |allowedDevice|
-          in its {{BluetoothPermissionData/allowedDevices}} list
-          with <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code>
-          the <a>same device</a> as <code>this.{{[[representedDevice]]}}</code>
-          and <code>|allowedDevice|.{{AllowedBluetoothDevice/mayUseGATT}}</code>
-          equal to `true`,
-          return <code>this.{{[[gatt]]}}</code>.
-        </li>
-        <li>
-          Otherwise, return `null`.
-        </li>
-      </ol>
-    </div>
+      <dt><a>TX Power Level</a></dt>
+      <dd>
+        Set <code><var>event</var>.txPower</code> to the AD data.
+      </dd>
 
-    <p class="note">
-      Scanning costs power,
-      so websites should avoid watching for advertisements unnecessarily,
-      and should call {{unwatchAdvertisements()}} to stop using power as soon as possible.
-    </p>
+      <dt><a>Service Data</a> - 16 bit UUID</dt>
+      <dt><a>Service Data</a> - 32 bit UUID</dt>
+      <dt><a>Service Data</a> - 128 bit UUID</dt>
+      <dd>
+        Add to <code><var>event</var>.serviceData</code> a mapping from the
+        <a>UUID</a> to an {{ArrayBuffer}} containing the service data.
+      </dd>
 
-    <div algorithm class="unstable">
-      <p>
-        The <code><dfn method for="BluetoothDevice">watchAdvertisements()</dfn></code> method,
-        when invoked,
-        MUST return <a>a new promise</a> |promise| and
-        run the following steps <a>in parallel</a>:
-      </p>
-      <ol>
-        <li>
-          Ensure that the UA is scanning for this device's advertisements.
-          The UA SHOULD NOT filter out "duplicate" advertisements for the same device.
-        </li>
-        <li>
-          If the UA fails to enable scanning,
-          <a>reject</a> |promise| with one of the following errors,
-          and abort these steps:
+      <dt><a>Appearance</a></dt>
+      <dd>
+        Set <code><var>event</var>.appearance</code> to the AD data.
+      </dd>
 
-          <dl class="switch">
-            <dt>The UA doesn't support scanning for advertisements</dt>
-            <dd>{{NotSupportedError}}</dd>
+      <dt>Otherwise</dt>
+      <dd>Skip to the next AD structure.</dd>
+    </dl>
 
-            <dt>Bluetooth is turned off</dt>
-            <dd>{{InvalidStateError}}</dd>
+1. <a>Fire an event</a> initialized as <code>new
+    {{BluetoothAdvertisingEvent}}("{{advertisementreceived}}",
+    <var>event</var>)</code>, with its {{Event/isTrusted}} attribute initialized
+    to `true`, at <var>deviceObj</var>.
 
-            <dt>Other reasons</dt>
-            <dd>{{UnknownError}}</dd>
-          </dl>
-        </li>
-        <li>
-          <a>Queue a task</a> to perform the following steps:
-          <ol>
-            <li>Set <code>this.{{watchingAdvertisements}}</code> to `true`.</li>
-            <li>Resolve |promise| with `undefined`.</li>
-          </ol>
-        </li>
-      </ol>
-    </div>
+</div>
 
-    <div algorithm class="unstable">
-      <p>
-        The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code> method,
-        when invoked,
-        MUST run the following steps:
-      </p>
-      <ol>
-        <li>Set <code>this.{{watchingAdvertisements}}</code> to `false`.</li>
-        <li>
-          If no more {{BluetoothDevice}}s in the whole UA
-          have {{watchingAdvertisements}} set to `true`,
-          the UA SHOULD stop scanning for advertisements.
-          Otherwise, if no more {{BluetoothDevice}}s representing the same device as `this`
-          have {{watchingAdvertisements}} set to `true`,
-          the UA SHOULD reconfigure the scan to avoid receiving reports for this device.
-        </li>
-      </ol>
-    </div>
+All fields in {{BluetoothAdvertisingEvent}} return the last value they were
+initialized or set to.
 
-    <section class="unstable">
-      <h4 id="advertising-events">Responding to Advertising Events</h4>
+<div algorithm="BluetoothAdvertisingEvent contructor">
+The <dfn constructor
+for="BluetoothAdvertisingEvent">BluetoothAdvertisingEvent(type, init)</dfn>
+constructor MUST perform the following steps:
 
-      <p>
-        When an <a>advertising event</a> arrives for a {{BluetoothDevice}}
-        with {{BluetoothDevice/watchingAdvertisements}} set,
-        the UA delivers an "{{advertisementreceived}}" event.
-      </p>
+1. Let <var>event</var> be the result of running the steps from
+    [[dom#constructing-events]] except for the
+    {{BluetoothAdvertisingEventInit/uuids}},
+    {{BluetoothAdvertisingEventInit/manufacturerData}}, and
+    {{BluetoothAdvertisingEventInit/serviceData}} members.
+1. If <code><var>init</var>.uuids</code> is set, initialize
+    <code><var>event</var>.uuids</code> to a new {{FrozenArray}} containing the
+    elements of <code><var>init</var>.uuids.map(
+    {{BluetoothUUID/getService()|BluetoothUUID.getService}})</code>.
+    Otherwise initialize <code><var>event</var>.uuids</code> to an empty
+    {{FrozenArray}}.
+1. For each mapping in <code><var>init</var>.manufacturerData</code>:
+    1. Let <var>code</var> be the key converted to an {{unsigned short}}.
+    1. Let <var>value</var> be the value.
+    1. If <var>value</var> is not a {{BufferSource}}, throw a {{TypeError}}.
+    1. Let <var>bytes</var> be a new <a>read only ArrayBuffer</a> containing
+        <a>a copy of the bytes held</a> by <var>value</var>.
+    1. Add a mapping from <var>code</var> to <code>new
+        DataView(<var>bytes</var>)</code> in
+        <code><var>event</var>.manufacturerData.{{BluetoothManufacturerDataMap/[[BackingMap]]}}</code>.
+1. For each mapping in <code><var>init</var>.serviceData</code>:
+    1. Let <var>key</var> be the key.
+    1. Let <var>service</var> be the result of calling
+        <code>BluetoothUUID.{{BluetoothUUID/getService()|getService}}(<var>key</var>).</code>
+    1. Let <var>value</var> be the value.
+    1. Set <var>value</var> is not a {{BufferSource}}, throw a {{TypeError}}.
+    1. Let <var>bytes</var> be a new <a>read only ArrayBuffer</a> containing
+        <a>a copy of the bytes held</a> by <var>value</var>.
+    1. Add a mapping from <var>service</var> to <code>new
+        DataView(<var>bytes</var>)</code> in
+        <code><var>event</var>.serviceData.{{BluetoothServiceDataMap/[[BackingMap]]}}</code>.
+1. Return <var>event</var>.
 
-      <pre class="idl">
-        [Exposed=Window, SecureContext]
-        interface BluetoothManufacturerDataMap {
-          readonly maplike&lt;unsigned short, DataView>;
-        };
-        [Exposed=Window, SecureContext]
-        interface BluetoothServiceDataMap {
-          readonly maplike&lt;UUID, DataView>;
-        };
-        [
-          Exposed=Window,
-          SecureContext
-        ]
-        interface BluetoothAdvertisingEvent : Event {
-          constructor(DOMString type, BluetoothAdvertisingEventInit init);
-          [SameObject]
-          readonly attribute BluetoothDevice device;
-          readonly attribute FrozenArray&lt;UUID> uuids;
-          readonly attribute DOMString? name;
-          readonly attribute unsigned short? appearance;
-          readonly attribute byte? txPower;
-          readonly attribute byte? rssi;
-          [SameObject]
-          readonly attribute BluetoothManufacturerDataMap manufacturerData;
-          [SameObject]
-          readonly attribute BluetoothServiceDataMap serviceData;
-        };
-        dictionary BluetoothAdvertisingEventInit : EventInit {
-          required BluetoothDevice device;
-          sequence&lt;(DOMString or unsigned long)> uuids;
-          DOMString name;
-          unsigned short appearance;
-          byte txPower;
-          byte rssi;
-          BluetoothManufacturerDataMap manufacturerData;
-          BluetoothServiceDataMap serviceData;
-        };
-      </pre>
-
-      <div class="note" heading="{{BluetoothAdvertisingEvent}} attributes"
-           dfn-for="BluetoothAdvertisingEvent" dfn-type="attribute"
-           link-for-hint="BluetoothAdvertisingEvent">
-        <p>
-          <dfn>device</dfn> is the {{BluetoothDevice}} that sent this advertisement.
-        </p>
-        <p>
-          <dfn>uuids</dfn> lists the Service UUIDs that
-          this advertisement says {{device}}'s GATT server supports.
-        </p>
-        <p>
-          <dfn>name</dfn> is {{device}}'s local name, or a prefix of it.
-        </p>
-        <p>
-          <dfn>appearance</dfn> is an <a>Appearance</a>, one of the values defined by
-          the {{org.bluetooth.characteristic.gap.appearance}} characteristic.
-        </p>
-        <p>
-          <dfn>txPower</dfn> is
-          the transmission power at which the device is broadcasting, measured in dBm.
-          This is used to compute the path loss as <code>this.txPower - this.rssi</code>.
-        </p>
-        <p>
-          <dfn>rssi</dfn> is
-          the power at which the advertisement was received, measured in dBm.
-          This is used to compute the path loss as <code>this.txPower - this.rssi</code>.
-        </p>
-        <p>
-          <dfn>manufacturerData</dfn> maps <code>unsigned short</code> Company Identifier Codes
-          to {{DataView}}s.
-        </p>
-        <p>
-          <dfn>serviceData</dfn> maps {{UUID}}s to {{DataView}}s.
-        </p>
-      </div>
-
-      <div class="example" id="example-interpret-ibeacon">
-        <p>
-          To retrieve a device and read the iBeacon data out of it,
-          a developer could use the following code.
-          Note that this API currently doesn't provide a way
-          to request devices with certain manufacturer data,
-          so the iBeacon will need to rotate its advertisements to include a known service
-          in order for users to select this device in the <code>requestDevice</code> dialog.
-        </p>
-
-        <pre highlight="js">
-          var known_service = "A service in the iBeacon's GATT server";
-          return navigator.bluetooth.requestDevice({
-            filters: [{services: [known_service]}]
-          }).then(device => {
-            device.watchAdvertisements();
-            device.addEventListener('advertisementreceived', interpretIBeacon);
-          });
-
-          function interpretIBeacon(event) {
-            var rssi = event.rssi;
-            var appleData = event.manufacturerData.get(<a
-                href="https://www.bluetooth.org/en-us/specification/assigned-numbers/company-identifiers"
-                title="Apple, Inc.'s Company Identifier">0x004C</a>);
-            if (appleData.byteLength != 23 ||
-              appleData.getUint16(0, false) !== 0x0215) {
-              console.log({isBeacon: false});
-            }
-            var uuidArray = new Uint8Array(appleData.buffer, 2, 16);
-            var major = appleData.getUint16(18, false);
-            var minor = appleData.getUint16(20, false);
-            var txPowerAt1m = -appleData.getInt8(22);
-            console.log({
-                isBeacon: true,
-                uuidArray,
-                major,
-                minor,
-                pathLossVs1m: txPowerAt1m - rssi});
-          });
-        </pre>
-
-        <p>
-          The format of iBeacon advertisements was derived from
-          <a href="http://www.warski.org/blog/2014/01/how-ibeacons-work/">How do iBeacons work?</a>
-          by Adam Warski.
-        </p>
-      </div>
-
-      <div algorithm="received advertising event" id="advertising-event-algorithm">
-        <p>
-          When the UA receives an <a>advertising event</a>
-          (consisting of an advertising packet and an optional scan response),
-          it MUST run the following steps:
-        </p>
-        <ol>
-          <li>
-            Let <var>device</var> be the <a>Bluetooth device</a> that sent the advertising event.
-          </li>
-          <li>
-            For each {{BluetoothDevice}} <var>deviceObj</var> in the UA
-            such that <var>device</var> is the <a>same device</a> as
-            <code><var>deviceObj</var>.{{[[representedDevice]]}}</code>,
-            <a>queue a task</a> on
-            <var>deviceObj</var>'s <a>relevant settings object</a>'s <a>responsible event loop</a>
-            to do the following sub-steps:
-            <ol>
-              <li>
-                If <code><var>deviceObj</var>.{{watchingAdvertisements}}</code> is `false`,
-                abort these sub-steps.
-              </li>
-              <li>
-                <a>Fire an `advertisementreceived` event</a>
-                for the advertising event at |deviceObj|.
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </div>
-
-      <div algorithm>
-        <p>
-          To <dfn export>fire an {{advertisementreceived}} event</dfn>
-          for an advertising event |adv| at a {{BluetoothDevice}} |deviceObj|,
-          the UA MUST perform the following steps:
-        </p>
-        <ol>
-          <li>
-            Let <var>event</var> be
-            <pre highlight="js">
-              {
-                bubbles: true,
-                device: <var>deviceObj</var>,
-                uuids: [],
-                manufacturerData: new Map(),
-                serviceData: new Map()
-              }
-            </pre>
-          </li>
-          <li>
-            If the <a>received signal strength</a> is available
-            for any packet in |adv|,
-            set <code><var>event</var>.rssi</code> to this signal strength in dBm.
-          </li>
-          <li>
-            For each <a>AD structure</a> in |adv|'s advertising packet and scan response,
-            select from the following steps depending on the AD type:
-            <dl class="switch">
-              <dt>Incomplete List of 16-bit <a lt="Service UUID Data Type">Service UUIDs</a></dt>
-              <dt>Complete List of 16-bit <a lt="Service UUID Data Type">Service UUIDs</a></dt>
-              <dt>Incomplete List of 32-bit <a lt="Service UUID Data Type">Service UUIDs</a></dt>
-              <dt>Complete List of 32-bit <a lt="Service UUID Data Type">Service UUIDs</a></dt>
-              <dt>Incomplete List of 128-bit <a lt="Service UUID Data Type">Service UUIDs</a></dt>
-              <dt>Complete List of 128-bit <a lt="Service UUID Data Type">Service UUIDs</a></dt>
-              <dd>Append the listed UUIDs to <code><var>event</var>.uuids</code>.</dd>
-
-              <dt>Shortened <a lt="Local Name Data Type">Local Name</a></dt>
-              <dt>Complete <a lt="Local Name Data Type">Local Name</a></dt>
-              <dd>
-                <a>UTF-8 decode without BOM</a> the AD data and
-                set <code><var>event</var>.name</code> to the result.
-
-                Note: We don't expose whether the name is complete
-                because existing APIs require
-                reading the raw advertisement to get this information,
-                and we want more evidence that it's useful
-                before adding a field to the API.
-              </dd>
-
-              <dt><a>Manufacturer Specific Data</a></dt>
-              <dd>
-                Add to <code><var>event</var>.manufacturerData</code>
-                a mapping from the 16-bit Company Identifier Code to
-                an {{ArrayBuffer}} containing the manufacturer-specific data.
-              </dd>
-
-              <dt><a>TX Power Level</a></dt>
-              <dd>
-                Set <code><var>event</var>.txPower</code> to the AD data.
-              </dd>
-
-              <dt><a>Service Data</a> - 16 bit UUID</dt>
-              <dt><a>Service Data</a> - 32 bit UUID</dt>
-              <dt><a>Service Data</a> - 128 bit UUID</dt>
-              <dd>
-                Add to <code><var>event</var>.serviceData</code>
-                a mapping from the <a>UUID</a> to
-                an {{ArrayBuffer}} containing the service data.
-              </dd>
-
-              <dt><a>Appearance</a></dt>
-              <dd>
-                Set <code><var>event</var>.appearance</code> to the AD data.
-              </dd>
-
-              <dt>Otherwise</dt>
-              <dd>Skip to the next AD structure.</dd>
-            </dl>
-          </li>
-          <li>
-            <a>Fire an event</a> initialized as
-            <code>new {{BluetoothAdvertisingEvent}}("{{advertisementreceived}}",
-              <var>event</var>)</code>,
-            with its {{Event/isTrusted}} attribute initialized to `true`,
-            at <var>deviceObj</var>.
-          </li>
-        </ol>
-      </div>
-
-      <p>
-        All fields in {{BluetoothAdvertisingEvent}} return
-        the last value they were initialized or set to.
-      </p>
-
-      <div algorithm>
-        <p>
-          The <dfn constructor for="BluetoothAdvertisingEvent">BluetoothAdvertisingEvent(type, init)</dfn>
-          constructor MUST perform the following steps:
-        </p>
-        <ol>
-          <li>
-            Let <var>event</var> be the result of running the steps from [[dom#constructing-events]]
-            except for the {{BluetoothAdvertisingEventInit/uuids}},
-            {{BluetoothAdvertisingEventInit/manufacturerData}},
-            and {{BluetoothAdvertisingEventInit/serviceData}} members.
-          </li>
-          <li>
-            If <code><var>init</var>.uuids</code> is set,
-            initialize <code><var>event</var>.uuids</code>
-            to a new {{FrozenArray}} containing the elements of
-            <code><var>init</var>.uuids.map({{BluetoothUUID/getService()|BluetoothUUID.getService}})</code>.
-            Otherwise initialize <code><var>event</var>.uuids</code> to an empty {{FrozenArray}}.
-          </li>
-          <li>
-            For each mapping in <code><var>init</var>.manufacturerData</code>:
-            <ol>
-              <li>
-                Let <var>code</var> be the key converted to an {{unsigned short}}.
-              </li>
-              <li>
-                Let <var>value</var> be the value.
-              </li>
-              <li>
-                If <var>value</var> is not a {{BufferSource}}, throw a {{TypeError}}.
-              </li>
-              <li>
-                Let <var>bytes</var> be a new <a>read only ArrayBuffer</a>
-                containing <a>a copy of the bytes held</a> by <var>value</var>.
-              </li>
-              <li>
-                Add a mapping from <var>code</var> to <code>new DataView(<var>bytes</var>)</code>
-                in <code><var>event</var>.manufacturerData.{{BluetoothManufacturerDataMap/[[BackingMap]]}}</code>.
-              </li>
-            </ol>
-          </li>
-          <li>
-            For each mapping in <code><var>init</var>.serviceData</code>:
-            <ol>
-              <li>
-                Let <var>key</var> be the key.
-              </li>
-              <li>
-                Let <var>service</var> be the result of calling
-                <code>BluetoothUUID.{{BluetoothUUID/getService()|getService}}(<var>key</var>).</code>
-              </li>
-              <li>
-                Let <var>value</var> be the value.
-              </li>
-              <li>
-                Set <var>value</var> is not a {{BufferSource}}, throw a {{TypeError}}.
-              </li>
-              <li>
-                Let <var>bytes</var> be a new <a>read only ArrayBuffer</a>
-                containing <a>a copy of the bytes held</a> by <var>value</var>.
-              </li>
-              <li>
-                Add a mapping from <var>service</var> to <code>new DataView(<var>bytes</var>)</code>
-                in <code><var>event</var>.serviceData.{{BluetoothServiceDataMap/[[BackingMap]]}}</code>.
-              </li>
-            </ol>
-          </li>
-          <li>Return <var>event</var>.</li>
-        </ol>
-      </div>
+</div>
 
       <section>
         <h5 dfn-type="interface">BluetoothManufacturerDataMap</h5>
@@ -2502,7 +2351,7 @@ it was initialized to.
       </section>
     </section>
   </section>
-</section>
+</div>
 
 <section>
   <h2 id="gatt-interaction">GATT Interaction</h2>


### PR DESCRIPTION
This change updates the spec source file to use more Markdown syntax in
order to improve readability. This commit updates the Section 4 of the
spec.

The following changes were performed:
* Heading tags were replaced with their Markdown equivalent, #.
* \<p\> tags were removed.
* \<ol\>, \<ul\>, \<li\> tags were reaplced with their Markdown equivalent, *
    and 1.
* \<table\> tags had the "data" class removed to fix their rendering so
    that they don't overflow past their containers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/471.html" title="Last updated on Feb 11, 2020, 10:29 PM UTC (4fa9fb6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/471/0534be7...odejesush:4fa9fb6.html" title="Last updated on Feb 11, 2020, 10:29 PM UTC (4fa9fb6)">Diff</a>