### PR TITLE
Use Markdown for Sections 6-9

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4102,692 +4102,621 @@ Response</a></code>, the UA MUST perform the following steps:
 
 </div>
 
-<section>
-  <h2 id="uuids">UUIDs</h2>
+# UUIDs # {#uuids}
 
-  <pre class="idl">typedef DOMString UUID;</pre>
-  <p>
-    A <a>UUID</a> string represents a 128-bit [[!RFC4122]] UUID.
-    A <dfn>valid UUID</dfn> is a string that matches
-    the [[!ECMAScript]] regexp
-    <code>/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/</code>.
-    That is, a <a>valid UUID</a> is lower-case and
-    does not use the 16- or 32-bit abbreviations defined by the Bluetooth standard.
-    All UUIDs returned from functions and attributes in this specification
-    MUST be <a>valid UUID</a>s.
-    If a function in this specification takes a parameter whose type is <a>UUID</a>
-    or a dictionary including a <a>UUID</a> attribute,
-    and the argument passed in any <a>UUID</a> slot is not a <a>valid UUID</a>,
-    the function MUST return <a>a promise rejected with</a> a <code>TypeError</code>
-    and abort its other steps.
-  </p>
-  <p class="note">
-    This standard provides the
-    <code>BluetoothUUID.<a for="BluetoothUUID">canonicalUUID(<var>alias</var>)</a></code> function
-    to map a 16- or 32-bit Bluetooth <a>UUID alias</a> to its 128-bit form.
-  </p>
-  <p class="note">
-    Bluetooth devices are required to convert 16- and 32-bit UUIDs to 128-bit UUIDs
-    before comparing them (as described in <a>Attribute Type</a>), but not all devices do so.
-    To interoperate with these devices,
-    if the UA has received a UUID from the device in one form (16-, 32-, or 128-bit),
-    it should send other aliases of that UUID back to the device in the same form.
-  </p>
+<xmp class="idl">
+  typedef DOMString UUID;
+</xmp>
 
-  <section>
-    <h3 id="standardized-uuids">Standardized UUIDs</h3>
+A <a>UUID</a> string represents a 128-bit [[!RFC4122]] UUID. A <dfn>valid
+UUID</dfn> is a string that matches the [[!ECMAScript]] regexp
+<code>/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/</code>.
+That is, a <a>valid UUID</a> is lower-case and does not use the 16- or 32-bit
+abbreviations defined by the Bluetooth standard. All UUIDs returned from
+functions and attributes in this specification MUST be <a>valid UUID</a>s. If a
+function in this specification takes a parameter whose type is <a>UUID</a> or a
+dictionary including a <a>UUID</a> attribute, and the argument passed in any
+<a>UUID</a> slot is not a <a>valid UUID</a>, the function MUST return <a>a
+promise rejected with</a> a <code>TypeError</code> and abort its other steps.
 
-    <p>
-      The Bluetooth SIG maintains a registry at [[BLUETOOTH-ASSIGNED]] of
-      UUIDs that identify services, characteristics, descriptors, and other entities.
-      This section provides a way for script to look up those UUIDs by name
-      so they don't need to be replicated in each application.
-    </p>
+<div class="note">
+  Note: This standard provides the <code>BluetoothUUID.<a
+  for="BluetoothUUID">canonicalUUID(<var>alias</var>)</a></code> function to map
+  a 16- or 32-bit Bluetooth <a>UUID alias</a> to its 128-bit form.
+</div>
 
-    <pre class="idl">
-      [Exposed=Window]
-      interface BluetoothUUID {
-        static UUID getService((DOMString or unsigned long) name);
-        static UUID getCharacteristic((DOMString or unsigned long) name);
-        static UUID getDescriptor((DOMString or unsigned long) name);
+<div class="note">
+  Note: Bluetooth devices are required to convert 16- and 32-bit UUIDs to
+  128-bit UUIDs before comparing them (as described in <a>Attribute Type</a>),
+  but not all devices do so. To interoperate with these devices, if the UA has
+  received a UUID from the device in one form (16-, 32-, or 128-bit), it should
+  send other aliases of that UUID back to the device in the same form.
+</div>
 
-        static UUID canonicalUUID([EnforceRange] unsigned long alias);
-      };
+## Standardized UUIDs ## {#standardized-uuids}
 
-      typedef (DOMString or unsigned long) BluetoothServiceUUID;
-      typedef (DOMString or unsigned long) BluetoothCharacteristicUUID;
-      typedef (DOMString or unsigned long) BluetoothDescriptorUUID;
-    </pre>
+The Bluetooth SIG maintains a registry at [[BLUETOOTH-ASSIGNED]] of UUIDs that
+identify services, characteristics, descriptors, and other entities. This
+section provides a way for script to look up those UUIDs by name so they don't
+need to be replicated in each application.
 
-    <p>
-      The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">canonicalUUID(<var>alias</var>)</dfn></code> method, when invoked,
-      MUST return <a>the 128-bit UUID represented</a>
-      by the 16- or 32-bit UUID alias <var>alias</var>.
-    </p>
-    <p class="note">
-      This algorithm consists of
-      replacing the top 32 bits of "<code>00000000-0000-1000-8000-00805f9b34fb</code>"
-      with the bits of the alias.
-      For example, <code>canonicalUUID(0xDEADBEEF)</code> returns
-      <code>"deadbeef-0000-1000-8000-00805f9b34fb"</code>.
-    </p>
+<xmp class="idl">
+  [Exposed=Window]
+  interface BluetoothUUID {
+    static UUID getService((DOMString or unsigned long) name);
+    static UUID getCharacteristic((DOMString or unsigned long) name);
+    static UUID getDescriptor((DOMString or unsigned long) name);
 
-    <div class="note">
-      <p>
-        <dfn typedef>BluetoothServiceUUID</dfn> represents
-        16- and 32-bit UUID aliases, <a>valid UUID</a>s,
-        and names defined in [[BLUETOOTH-ASSIGNED-SERVICES]],
-        or, equivalently, the values for which
-        {{BluetoothUUID/getService()|BluetoothUUID.getService()}} does not throw an exception.
-      </p>
-      <p>
-        <dfn typedef>BluetoothCharacteristicUUID</dfn> represents
-        16- and 32-bit UUID aliases, <a>valid UUID</a>s,
-        and names defined in [[BLUETOOTH-ASSIGNED-CHARACTERISTICS]],
-        or, equivalently, the values for which
-        {{BluetoothUUID/getCharacteristic()|BluetoothUUID.getCharacteristic()}} does not throw an exception.
-      </p>
-      <p>
-        <dfn typedef>BluetoothDescriptorUUID</dfn> represents
-        16- and 32-bit UUID aliases, <a>valid UUID</a>s,
-        and names defined in [[BLUETOOTH-ASSIGNED-DESCRIPTORS]],
-        or, equivalently, the values for which
-        {{BluetoothUUID/getDescriptor()|BluetoothUUID.getDescriptor()}} does not throw an exception.
-      </p>
-    </div>
+    static UUID canonicalUUID([EnforceRange] unsigned long alias);
+  };
 
-    <div algorithm>
-      <p>
-        To <dfn>ResolveUUIDName</dfn>(<var>name</var>,
-        <var>assigned numbers table</var>, <var>prefix</var>),
-        the UA MUST perform the following steps:
-      </p>
-      <ol>
-        <li>
-          If <var>name</var> is an <code>unsigned long</code>,
-          return {{BluetoothUUID/canonicalUUID()|BluetoothUUID.canonicalUUID}}(name)</code> and abort these steps.
-        </li>
-        <li>
-          If <var>name</var> is a <a>valid UUID</a>,
-          return <var>name</var> and abort these steps.
-        </li>
-        <li>
-          If the string <code><var>prefix</var> + "." + <var>name</var></code>
-          appears in <var>assigned numbers table</var>,
-          let <var>alias</var> be its assigned number,
-          and return {{BluetoothUUID/canonicalUUID()|BluetoothUUID.canonicalUUID}}(<var>alias</var>)</code>.
-        </li>
-        <li>
-          Otherwise, throw a {{TypeError}}.
-        </li>
-      </ol>
-    </div>
+  typedef (DOMString or unsigned long) BluetoothServiceUUID;
+  typedef (DOMString or unsigned long) BluetoothCharacteristicUUID;
+  typedef (DOMString or unsigned long) BluetoothDescriptorUUID;
+</xmp>
 
-    <p>
-      The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">getService(<var>name</var>)</dfn></code> method, when invoked,
-      MUST return <a>ResolveUUIDName</a>(<code><var>name</var></code>,
-      [[!BLUETOOTH-ASSIGNED-SERVICES]], "org.bluetooth.service").
-    </p>
-    <p>
-      The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">getCharacteristic(<var>name</var>)</dfn></code> method, when invoked,
-      MUST return <a>ResolveUUIDName</a>(<code><var>name</var></code>,
-      [[!BLUETOOTH-ASSIGNED-CHARACTERISTICS]], "org.bluetooth.characteristic").
-    </p>
-    <p>
-      The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">getDescriptor(<var>name</var>)</dfn></code> method, when invoked,
-      MUST return <a>ResolveUUIDName</a>(<code><var>name</var></code>,
-      [[!BLUETOOTH-ASSIGNED-DESCRIPTORS]], "org.bluetooth.descriptor").
-    </p>
+The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">
+canonicalUUID(<var>alias</var>)</dfn></code> method, when invoked, MUST return
+<a>the 128-bit UUID represented</a> by the 16- or 32-bit UUID alias
+<var>alias</var>.
 
-    <div class="example">
-      <p>
-        <code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("<a idl lt="org.bluetooth.service.cycling_power">
-          cycling_power</a>")</code>
-        returns <code>"00001818-0000-1000-8000-00805f9b34fb"</code>.
-      </p>
-      <p>
-        <code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("00001801-0000-1000-8000-00805f9b34fb")</code>
-        returns <code>"00001801-0000-1000-8000-00805f9b34fb"</code>.
-      </p>
-      <p>
-        <code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("unknown-service")</code>
-        throws a {{TypeError}}.
-      </p>
-      <p>
-        <code>{{BluetoothUUID/getCharacteristic()|BluetoothUUID.getCharacteristic}}("{{org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list|ieee_11073-20601_regulatory_certification_data_list}}")</code>
-        returns <code>"00002a2a-0000-1000-8000-00805f9b34fb"</code>.
-      </p>
-      <p>
-        <code>{{BluetoothUUID/getDescriptor()|BluetoothUUID.getDescriptor}}("{{org.bluetooth.descriptor.gatt.characteristic_presentation_format|gatt.characteristic_presentation_format}}")</code>
-        returns <code>"00002904-0000-1000-8000-00805f9b34fb"</code>.
-      </p>
-    </div>
-  </section>
-</section>
+<div class="note">
+  Note: This algorithm consists of replacing the top 32 bits of
+  "<code>00000000-0000-1000-8000-00805f9b34fb</code>" with the bits of the
+  alias. For example, <code>canonicalUUID(0xDEADBEEF)</code> returns
+  <code>"deadbeef-0000-1000-8000-00805f9b34fb"</code>.
+</div>
 
-<section>
-  <h2 id="the-gatt-blocklist">The GATT Blocklist</h2>
+<div class="note">
+  <dfn typedef>BluetoothServiceUUID</dfn> represents 16- and 32-bit UUID
+  aliases, <a>valid UUID</a>s, and names defined in
+  [[BLUETOOTH-ASSIGNED-SERVICES]], or, equivalently, the values for which
+  {{BluetoothUUID/getService()|BluetoothUUID.getService()}} does not throw an
+  exception.
 
-  <p>
-    This specification relies on a blocklist file in the
-    <a href="https://github.com/WebBluetoothCG/registries">
-       https://github.com/WebBluetoothCG/registries</a> repository
-    to restrict the set of GATT attributes a website can access.
-  </p>
+  <dfn typedef>BluetoothCharacteristicUUID</dfn> represents 16- and 32-bit UUID
+  aliases, <a>valid UUID</a>s, and names defined in
+  [[BLUETOOTH-ASSIGNED-CHARACTERISTICS]], or, equivalently, the values for which
+  {{BluetoothUUID/getCharacteristic()|BluetoothUUID.getCharacteristic()}} does
+  not throw an exception.
 
-  <div algorithm>
-    <p>
-      The result of <dfn>parsing the blocklist</dfn> at a URL <var>url</var>
-      is a map from <a>valid UUID</a>s to tokens, or an error,
-      produced by the following algorithm:
-    </p>
+  <dfn typedef>BluetoothDescriptorUUID</dfn> represents 16- and 32-bit UUID
+  aliases, <a>valid UUID</a>s, and names defined in
+  [[BLUETOOTH-ASSIGNED-DESCRIPTORS]], or, equivalently, the values for which
+  {{BluetoothUUID/getDescriptor()|BluetoothUUID.getDescriptor()}} does not throw
+  an exception.
+</div>
+
+<div algorithm="resolve UUID name">
+To <dfn>ResolveUUIDName</dfn>(<var>name</var>, <var>assigned numbers
+table</var>, <var>prefix</var>), the UA MUST perform the following steps:
+
+1. If <var>name</var> is an <code>unsigned long</code>, return
+    {{BluetoothUUID/canonicalUUID()|BluetoothUUID.canonicalUUID}}(name)</code>
+    and abort these steps.
+1. If <var>name</var> is a <a>valid UUID</a>, return <var>name</var> and abort
+    these steps.
+1. If the string <code><var>prefix</var> + "." + <var>name</var></code> appears
+    in <var>assigned numbers table</var>, let <var>alias</var> be its assigned
+    number, and return
+    {{BluetoothUUID/canonicalUUID()|BluetoothUUID.canonicalUUID}}(<var>alias</var>)</code>.
+1. Otherwise, throw a {{TypeError}}.
+
+</div>
+
+The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">
+getService(<var>name</var>)</dfn></code> method, when invoked, MUST return
+<a>ResolveUUIDName</a>(<code><var>name</var></code>,
+[[!BLUETOOTH-ASSIGNED-SERVICES]], "org.bluetooth.service").
+
+The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">
+getCharacteristic(<var>name</var>)</dfn></code> method, when invoked, MUST
+return <a>ResolveUUIDName</a>(<code><var>name</var></code>,
+[[!BLUETOOTH-ASSIGNED-CHARACTERISTICS]], "org.bluetooth.characteristic").
+
+The static <code>BluetoothUUID.<dfn method for="BluetoothUUID">
+getDescriptor(<var>name</var>)</dfn></code> method, when invoked, MUST return
+<a>ResolveUUIDName</a>(<code><var>name</var></code>,
+[[!BLUETOOTH-ASSIGNED-DESCRIPTORS]], "org.bluetooth.descriptor").
+
+<div class="example">
+<code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("<a idl lt="org.bluetooth.service.cycling_power"> cycling_power</a>")</code>
+returns <code>"00001818-0000-1000-8000-00805f9b34fb"</code>.
+
+<code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("00001801-0000-1000-8000-00805f9b34fb")</code> returns
+<code>"00001801-0000-1000-8000-00805f9b34fb"</code>.
+
+<code>{{BluetoothUUID/getService()|BluetoothUUID.getService}}("unknown-service")</code> throws a {{TypeError}}.
+
+<code>{{BluetoothUUID/getCharacteristic()|BluetoothUUID.getCharacteristic}}("{{org.bluetooth.characteristic.ieee_11073-20601_regulatory_certification_data_list|ieee_11073-20601_regulatory_certification_data_list}}")</code>
+returns <code>"00002a2a-0000-1000-8000-00805f9b34fb"</code>.
+
+<code>{{BluetoothUUID/getDescriptor()|BluetoothUUID.getDescriptor}}("{{org.bluetooth.descriptor.gatt.characteristic_presentation_format|gatt.characteristic_presentation_format}}")</code>
+returns <code>"00002904-0000-1000-8000-00805f9b34fb"</code>.
+</div>
+
+# The GATT Blocklist # {#the-gatt-blocklist}
+
+This specification relies on a blocklist file in the
+<a href="https://github.com/WebBluetoothCG/registries">
+  https://github.com/WebBluetoothCG/registries</a> repository
+to restrict the set of GATT attributes a website can access.
+
+<div algorithm="parsing the GATT blocklist">
+The result of <dfn>parsing the blocklist</dfn> at a URL <var>url</var> is a map
+from <a>valid UUID</a>s to tokens, or an error, produced by the following
+algorithm:
+
+1. Fetch <var>url</var>, and let <var>contents</var> be its body, decoded as
+    UTF-8.
+1. Let <var>lines</var> be <var>contents</var> split on <code>'\n'</code>.
+1. Let <var>result</var> be an empty map.
+1. For each <var>line</var> in <var>lines</var>, do the following sub-steps:
+    1. If <var>line</var> is empty or its first character is <code>'#'</code>,
+        continue to the next line.
+    1. If <var>line</var> consists of just a <a>valid UUID</a>, let
+        <var>uuid</var> be that UUID and let <var>token</var> be
+        "<code>exclude</code>".
+    1. If <var>line</var> consists of a <a>valid UUID</a>, a space (U+0020), and
+        one of the tokens "<code>exclude-reads</code>" or
+        "<code>exclude-writes</code>", let <var>uuid</var> be that UUID and let
+        <var>token</var> be that token.
+    1. Otherwise, return an error and abort these steps.
+    1. If <var>uuid</var> is already in <var>result</var>, return an error and
+        abort these steps.
+    1. Add a mapping in <var>result</var> from <var>uuid</var> to <var>token</var>.
+1. Return <var>result</var>.
+
+</div>
+
+The <dfn>GATT blocklist</dfn> is the result of <a>parsing the blocklist</a> at
+<a href="https://github.com/WebBluetoothCG/registries/blob/master/gatt_blocklist.txt">
+  https://github.com/WebBluetoothCG/registries/blob/master/gatt_blocklist.txt</a>.
+The UA should re-fetch the blocklist periodically, but it's unspecified how often.
+
+A <a>UUID</a> is <dfn>blocklisted</dfn> if either the <a>GATT blocklist</a>'s
+value is an error, or the UUID maps to "<code>exclude</code>" in the <a>GATT
+blocklist</a>.
+
+A <a>UUID</a> is <dfn>blocklisted for reads</dfn> if either the <a>GATT
+blocklist</a>'s value is an error, or the UUID maps to either
+"<code>exclude</code>" or "<code>exclude-reads</code>" in the <a>GATT
+blocklist</a>.
+
+A <a>UUID</a> is <dfn>blocklisted for writes</dfn> if either the <a>GATT
+blocklist</a>'s value is an error, or the UUID maps to either
+"<code>exclude</code>" or "<code>exclude-writes</code>" in the <a>GATT
+blocklist</a>.
+
+# Extensions to the Navigator Interface # {#navigator-extensions}
+
+<xmp class="idl">
+  [SecureContext]
+  partial interface Navigator {
+    [SameObject]
+    readonly attribute Bluetooth bluetooth;
+  };
+</xmp>
+
+# Terminology and Conventions # {#terminology}
+
+  This specification uses a few conventions and several terms from other
+  specifications. This section lists those and links to their primary
+  definitions.
+
+When an algorithm in this specification uses a name defined in this or another
+specification, the name MUST resolve to its initial value, ignoring any changes
+that have been made to the name in the current execution environment. For
+example, when the {{Bluetooth/requestDevice()}} algorithm says to call
+<code>{{Array.prototype.map}}.call(<var>filter</var>.services,
+  {{BluetoothUUID/getService()|BluetoothUUID.getService}})</code>,
+this MUST apply the {{Array.prototype.map}} algorithm defined in [[ECMAScript]]
+with <code><var>filter</var>.services</code> as its <code>this</code> parameter
+and the algorithm defined in <a href="#standardized-uuids"></a> for
+{{BluetoothUUID/getService()|BluetoothUUID.getService}} as its
+<code>callbackfn</code> parameter, regardless of any modifications that have
+been made to <code>window</code>, <code>Array</code>,
+<code>Array.prototype</code>, <code>Array.prototype.map</code>,
+<code>Function</code>, <code>Function.prototype</code>,
+<code>BluetoothUUID</code>, <code>BluetoothUUID.getService</code>, or other
+objects.
+
+This specification uses a read-only type that is similar to WebIDL's
+{{FrozenArray}}.
+
+* A <dfn>read only ArrayBuffer</dfn> has {{ArrayBuffer}}'s values and interface,
+    except that attempting to write to its contents or transfer it has the same
+    effect as trying to write to a {{FrozenArray}}'s contents. This applies to
+    {{TypedArray}}s and {{DataView}}s wrapped around the {{ArrayBuffer}} too.
+
+<dl>
+  <dt>[[!BLUETOOTH42]]</dt>
+  <dd>
     <ol>
-      <li>Fetch <var>url</var>, and let <var>contents</var> be its body, decoded as UTF-8.</li>
-      <li>Let <var>lines</var> be <var>contents</var> split on <code>'\n'</code>.</li>
-      <li>
-        Let <var>result</var> be an empty map.
-      </li>
-      <li>
-        For each <var>line</var> in <var>lines</var>, do the following sub-steps:
-        <ol>
-          <li>
-            If <var>line</var> is empty or its first character is <code>'#'</code>,
-            continue to the next line.
+      <li value="1">Architecture &amp; Terminology Overview
+        <ol type="A">
+          <li value="1">General Description
+            <ol>
+              <li value="2">Overview of Bluetooth Low Energy Operation
+                (defines <dfn lt="advertising event|advertising events">advertising events</dfn>)
+              </li>
+            </ol>
           </li>
-          <li>
-            If <var>line</var> consists of just a <a>valid UUID</a>,
-            let <var>uuid</var> be that UUID and
-            let <var>token</var> be "<code>exclude</code>".
-          </li>
-          <li>
-            If <var>line</var> consists of a <a>valid UUID</a>, a space (U+0020),
-            and one of the tokens "<code>exclude-reads</code>" or "<code>exclude-writes</code>",
-            let <var>uuid</var> be that UUID and
-            let <var>token</var> be that token.
-          </li>
-          <li>
-            Otherwise, return an error and abort these steps.
-          </li>
-          <li>
-            If <var>uuid</var> is already in <var>result</var>,
-            return an error and abort these steps.
-          </li>
-          <li>
-            Add a mapping in <var>result</var> from <var>uuid</var> to <var>token</var>.
+          <li value="4">Communication Topology and Operation
+            <ol>
+              <li value="2">Operational Procedures and Modes
+                <ol>
+                  <li value="1">BR/EDR Procedures
+                    <ol>
+                      <li value="1">Inquiry (Discovering) Procedure
+                        <ol>
+                          <li value="1"><dfn>Extended Inquiry Response</dfn></li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
           </li>
         </ol>
       </li>
-      <li>Return <var>result</var>.</li>
+      <li value="2">Core System Package [BR/EDR Controller volume]
+        <ol type="A">
+          <li value="5">Host Controller Interface Functional Specification
+            <ol>
+              <li value="7">HCI Commands and Events
+                <ol>
+                  <li value="4">Informational Parameters
+                    <ol>
+                      <li value="6"><dfn>Read BD_ADDR Command</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="5">Status Parameters
+                    <ol>
+                      <li value="4">
+                        Read <dfn lt="RSSI|Received Signal Strength">
+                                  <abbr title="Received Signal Strength Indication">
+                                          RSSI</abbr></dfn> Command
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li value="3">Core System Package [Host volume]
+        <ol type="A">
+          <li value="2">Service Discovery Protocol (SDP) Specification
+            <ol>
+              <li value="2">Overview
+                <ol>
+                  <li value="5"><dfn>Searching for Services</dfn>
+                    <ol>
+                      <li value="1"><dfn>UUID</dfn>
+                        (defines <dfn>UUID alias</dfn>es and
+                        the algorithm to compute <dfn>the 128-bit UUID represented</dfn>
+                        by a UUID alias)
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li value="3">Generic Access Profile
+            <ol>
+              <li value="2">Profile Overview
+                <ol>
+                  <li value="2">Profile Roles
+                    <ol>
+                      <li value="2">Roles when Operating over an LE Physical Transport
+                        <ol>
+                          <li value="1"><dfn>Broadcaster</dfn> Role</li>
+                          <li value="2"><dfn>Observer</dfn> Role</li>
+                          <li value="3"><dfn>Peripheral</dfn> Role</li>
+                          <li value="4"><dfn>Central</dfn> Role</li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="3">User Interface Aspects
+                <ol>
+                  <li value="2">Representation of Bluetooth Parameters
+                    <ol>
+                      <li value="2"><dfn>Bluetooth Device Name</dfn> (the user-friendly name)
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="6">Idle Mode Procedures &mdash; BR/EDR Physical Transport
+                <ol>
+                  <li value="4"><dfn>Device Discovery Procedure</dfn></li>
+                  <li value="5"><dfn>BR/EDR Bonding Procedure</dfn></li>
+                </ol>
+              </li>
+              <li value="9">Operational Modes and Procedures &mdash; LE Physical Transport
+                <ol>
+                  <li value="1">Broadcast Mode and Observation Procedure
+                    <ol>
+                      <li value="2"><dfn>Observation Procedure</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="2">Discovery Modes and Procedures
+                    <ol>
+                      <li value="6"><dfn>General Discovery Procedure</dfn></li>
+                      <li value="7"><dfn>Name Discovery Procedure</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="3">Connection Modes and Procedures</li>
+                  <li value="4">Bonding Modes and Procedures
+                    <ol>
+                      <li value="4"><dfn>LE Bonding Procedure</dfn></li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="10">Security Aspects &mdash; LE Physical Transport
+                <ol>
+                  <li value="7"><dfn>Privacy Feature</dfn></li>
+                  <li value="8">Random Device Address
+                    <ol>
+                      <li value="1"><dfn>Static Address</dfn></li>
+                      <li value="2"><dfn>Private address</dfn>
+                        <ol>
+                          <li value="3">
+                            <dfn>Resolvable Private Address Resolution Procedure</dfn>
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="11"><dfn>Advertising Data</dfn> and Scan Response Data Format
+                (defines <dfn>AD structure</dfn>)
+              </li>
+              <li value="15">Bluetooth Device Requirements
+                <ol>
+                  <li value="1">Bluetooth Device Address (defines <dfn>BD_ADDR</dfn>)
+                    <ol>
+                      <li value="1">Bluetooth Device Address Types
+                        <ol>
+                          <li value="1"><dfn>Public Bluetooth Address</dfn></li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="16">Definitions
+                (defines <dfn>bond</dfn>)
+              </li>
+            </ol>
+          </li>
+          <li value="6">Attribute Protocol (ATT)
+            <ol>
+              <li value="3">Protocol Requirements
+                <ol>
+                  <li value="2">Basic Concepts
+                    <ol>
+                      <li value="1"><dfn>Attribute Type</dfn></li>
+                      <li value="2"><dfn>Attribute Handle</dfn></li>
+                      <li value="9"><dfn>Long Attribute Values</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="4">Attribute Protocol Pdus
+                    <ol>
+                      <li value="1">Error Handling
+                        <ol>
+                          <li value="1"><dfn>Error Response</dfn></li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li value="7"><dfn lt="Generic Attribute Profile|GATT">Generic Attribute Profile</dfn> (GATT)
+            <ol>
+              <li value="2">Profile Overview
+                <ol>
+                  <li value="2">Configurations and Roles
+                    (defines <dfn>GATT Client</dfn> and <dfn>GATT Server</dfn>)
+                  </li>
+                  <li value="4">
+                    <dfn>Profile Fundamentals</dfn>,
+                    defines the <dfn>ATT Bearer</dfn>
+                  </li>
+                  <li value="5">Attribute Protocol
+                    <ol>
+                      <li value="2"><dfn>Attribute Caching</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="6"><dfn>GATT Profile Hierarchy</dfn>
+                    <ol>
+                      <li value="2"><dfn>Service</dfn></li>
+                      <li value="3"><dfn>Included Service</dfn>s</li>
+                      <li value="4"><dfn>Characteristic</dfn></li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="3"><dfn>Service Interoperability Requirements</dfn>
+                <ol>
+                  <li value="1"><dfn>Service Definition</dfn></li>
+                  <li value="3">Characteristic Definition
+                    <ol>
+                      <li value="1">Characteristic Declaration
+                        <ol>
+                          <li value="1"><dfn>Characteristic Properties</dfn></li>
+                        </ol>
+                      </li>
+                      <li value="3">Characteristic <dfn>Descriptor</dfn> Declarations
+                        <ol>
+                          <li value="1"><dfn>Characteristic Extended Properties</dfn></li>
+                          <li value="3"><dfn>Client Characteristic Configuration</dfn></li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="4">GATT Feature Requirements &mdash; defines the
+                <dfn lt="GATT procedure|GATT procedures">GATT procedures</dfn>.
+                <ol>
+                  <li value="3">Server Configuration
+                    <ol>
+                      <li value="1"><dfn>Exchange MTU</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="4"><dfn>Primary Service Discovery</dfn>
+                    <ol>
+                      <li value="1">Discover All Primary Services</li>
+                      <li value="2"><dfn>Discover Primary Service by Service UUID</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="5"><dfn>Relationship Discovery</dfn>
+                    <ol>
+                      <li value="1">Find Included Services</li>
+                    </ol>
+                  </li>
+                  <li value="6"><dfn>Characteristic Discovery</dfn>
+                    <ol>
+                      <li value="1">Discover All Characteristics of a Service</li>
+                      <li value="2"><dfn>Discover Characteristics by UUID</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="7"><dfn>Characteristic Descriptor Discovery</dfn>
+                    <ol>
+                      <li value="1"><dfn>Discover All Characteristic Descriptors</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="8"><dfn>Characteristic Value Read</dfn></li>
+                  <li value="9"><dfn>Characteristic Value Write</dfn>
+                    <ol>
+                      <li value="1"><dfn>Write Without Response</dfn></li>
+                      <li value="2"><dfn>Write Characteristic Value</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="10"><dfn>Characteristic Value Notification</dfn></li>
+                  <li value="11"><dfn>Characteristic Value Indications</dfn></li>
+                  <li value="12"><dfn>Characteristic Descriptors</dfn>
+                    <ol>
+                      <li value="1"><dfn>Read Characteristic Descriptors</dfn></li>
+                      <li value="2"><dfn>Read Long Characteristic Descriptors</dfn></li>
+                      <li value="3"><dfn>Write Characteristic Descriptors</dfn></li>
+                      <li value="4"><dfn>Write Long Characteristic Descriptors</dfn></li>
+                    </ol>
+                  </li>
+                  <li value="14"><dfn local-lt="procedure times out">Procedure Timeouts</dfn></li>
+                </ol>
+              </li>
+              <li value="6"><dfn>GAP Interoperability Requirements</dfn>
+                <ol>
+                  <li value="1">BR/EDR GAP Interoperability Requirements
+                    <ol>
+                      <li value="1">Connection Establishment</li>
+                    </ol>
+                  </li>
+                  <li value="2">LE GAP Interoperability Requirements
+                    <ol>
+                      <li value="1">Connection Establishment</li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="7">Defined Generic Attribute Profile Service
+                <ol>
+                  <li value="1"><dfn>Service Changed</dfn></li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li value="8">Security Manager Specification
+            <ol>
+              <li value="2">Security Manager
+                <ol>
+                  <li value="4">Security in Bluetooth Low Energy
+                    <ol>
+                      <li value="1"><dfn>Definition of Keys and Values</dfn>,
+                        defines the
+                        <dfn lt="Identity Resolving Key|IRK">Identity Resolving Key</dfn>
+                        (<abbr title="Identity Resolving Key">IRK</abbr>)
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+      <li value="6">Core System Package [Low Energy Controller volume]
+        <ol type="A">
+          <li value="2">Link Layer Specification
+            <ol>
+              <li value="1">General Description
+                <ol>
+                  <li value="3">Device Address
+                    <ol>
+                      <li value="1"><dfn>Public Device Address</dfn></li>
+                      <li value="2">Random Device Address
+                        <ol>
+                          <li value="1"><dfn>Static Device Address</dfn></li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li value="4">Air Interface Protocol
+                <ol>
+                  <li value="4">Non-Connected States
+                    <ol>
+                      <li value="3">Scanning State
+                        <ol>
+                          <li value="1"><dfn>Passive Scanning</dfn></li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
     </ol>
-  </div>
-
-  <p>
-    The <dfn>GATT blocklist</dfn> is the result of <a>parsing the blocklist</a> at
-    <a href="https://github.com/WebBluetoothCG/registries/blob/master/gatt_blocklist.txt">
-       https://github.com/WebBluetoothCG/registries/blob/master/gatt_blocklist.txt</a>.
-    The UA should re-fetch the blocklist periodically, but it's unspecified how often.
-  </p>
-
-  <p>
-    A <a>UUID</a> is <dfn>blocklisted</dfn> if either
-    the <a>GATT blocklist</a>'s value is an error,
-    or the UUID maps to "<code>exclude</code>" in the <a>GATT blocklist</a>.
-  </p>
-  <p>
-    A <a>UUID</a> is <dfn>blocklisted for reads</dfn> if either
-    the <a>GATT blocklist</a>'s value is an error,
-    or the UUID maps to either "<code>exclude</code>" or "<code>exclude-reads</code>"
-    in the <a>GATT blocklist</a>.
-  </p>
-  <p>
-    A <a>UUID</a> is <dfn>blocklisted for writes</dfn> if either
-    the <a>GATT blocklist</a>'s value is an error,
-    or the UUID maps to either "<code>exclude</code>" or "<code>exclude-writes</code>"
-    in the <a>GATT blocklist</a>.
-  </p>
-</section>
-
-<section>
-  <h2 id="navigator-extensions">Extensions to the Navigator Interface</h2>
-
-  <pre class="idl">
-    [SecureContext]
-    partial interface Navigator {
-      [SameObject]
-      readonly attribute Bluetooth bluetooth;
-    };
-  </pre>
-</section>
-
-<section>
-  <h2 id="terminology">Terminology and Conventions</h2>
-
-  <p>
-    This specification uses a few conventions and several terms from other specifications.
-    This section lists those and links to their primary definitions.
-  </p>
-
-  <p>
-    When an algorithm in this specification uses a name defined in this or another specification,
-    the name MUST resolve to its initial value,
-    ignoring any changes that have been made to the name in the current execution environment.
-    For example, when the {{Bluetooth/requestDevice()}} algorithm says to call
-    <code>{{Array.prototype.map}}.call(<var>filter</var>.services,
-      {{BluetoothUUID/getService()|BluetoothUUID.getService}})</code>,
-    this MUST apply the
-    {{Array.prototype.map}} algorithm defined in [[ECMAScript]]
-    with <code><var>filter</var>.services</code> as its <code>this</code> parameter and
-    the algorithm defined in <a href="#standardized-uuids"></a>
-    for {{BluetoothUUID/getService()|BluetoothUUID.getService}}
-    as its <code>callbackfn</code> parameter,
-    regardless of any modifications that have been made to <code>window</code>,
-    <code>Array</code>, <code>Array.prototype</code>, <code>Array.prototype.map</code>,
-    <code>Function</code>, <code>Function.prototype</code>, <code>BluetoothUUID</code>,
-    <code>BluetoothUUID.getService</code>, or other objects.
-  </p>
-
-  <p>
-    This specification uses a read-only type
-    that is similar to WebIDL's {{FrozenArray}}.
-  </p>
-  <ul>
-    <li>
-      A <dfn>read only ArrayBuffer</dfn> has {{ArrayBuffer}}'s values and interface,
-      except that attempting to write to its contents or transfer it
-      has the same effect as trying to write to a {{FrozenArray}}'s contents.
-      This applies to {{TypedArray}}s and {{DataView}}s
-      wrapped around the {{ArrayBuffer}} too.
-    </li>
-  </ul>
-
-  <dl>
-    <dt>[[!BLUETOOTH42]]</dt>
-    <dd>
-      <ol>
-        <li value="1">Architecture &amp; Terminology Overview
-          <ol type="A">
-            <li value="1">General Description
-              <ol>
-                <li value="2">Overview of Bluetooth Low Energy Operation
-                  (defines <dfn lt="advertising event|advertising events">advertising events</dfn>)
-                </li>
-              </ol>
-            </li>
-            <li value="4">Communication Topology and Operation
-              <ol>
-                <li value="2">Operational Procedures and Modes
-                  <ol>
-                    <li value="1">BR/EDR Procedures
-                      <ol>
-                        <li value="1">Inquiry (Discovering) Procedure
-                          <ol>
-                            <li value="1"><dfn>Extended Inquiry Response</dfn></li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-        <li value="2">Core System Package [BR/EDR Controller volume]
-          <ol type="A">
-            <li value="5">Host Controller Interface Functional Specification
-              <ol>
-                <li value="7">HCI Commands and Events
-                  <ol>
-                    <li value="4">Informational Parameters
-                      <ol>
-                        <li value="6"><dfn>Read BD_ADDR Command</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="5">Status Parameters
-                      <ol>
-                        <li value="4">
-                          Read <dfn lt="RSSI|Received Signal Strength">
-                                    <abbr title="Received Signal Strength Indication">
-                                           RSSI</abbr></dfn> Command
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-        <li value="3">Core System Package [Host volume]
-          <ol type="A">
-            <li value="2">Service Discovery Protocol (SDP) Specification
-              <ol>
-                <li value="2">Overview
-                  <ol>
-                    <li value="5"><dfn>Searching for Services</dfn>
-                      <ol>
-                        <li value="1"><dfn>UUID</dfn>
-                          (defines <dfn>UUID alias</dfn>es and
-                          the algorithm to compute <dfn>the 128-bit UUID represented</dfn>
-                          by a UUID alias)
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li value="3">Generic Access Profile
-              <ol>
-                <li value="2">Profile Overview
-                  <ol>
-                    <li value="2">Profile Roles
-                      <ol>
-                        <li value="2">Roles when Operating over an LE Physical Transport
-                          <ol>
-                            <li value="1"><dfn>Broadcaster</dfn> Role</li>
-                            <li value="2"><dfn>Observer</dfn> Role</li>
-                            <li value="3"><dfn>Peripheral</dfn> Role</li>
-                            <li value="4"><dfn>Central</dfn> Role</li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="3">User Interface Aspects
-                  <ol>
-                    <li value="2">Representation of Bluetooth Parameters
-                      <ol>
-                        <li value="2"><dfn>Bluetooth Device Name</dfn> (the user-friendly name)
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="6">Idle Mode Procedures &mdash; BR/EDR Physical Transport
-                  <ol>
-                    <li value="4"><dfn>Device Discovery Procedure</dfn></li>
-                    <li value="5"><dfn>BR/EDR Bonding Procedure</dfn></li>
-                  </ol>
-                </li>
-                <li value="9">Operational Modes and Procedures &mdash; LE Physical Transport
-                  <ol>
-                    <li value="1">Broadcast Mode and Observation Procedure
-                      <ol>
-                        <li value="2"><dfn>Observation Procedure</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="2">Discovery Modes and Procedures
-                      <ol>
-                        <li value="6"><dfn>General Discovery Procedure</dfn></li>
-                        <li value="7"><dfn>Name Discovery Procedure</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="3">Connection Modes and Procedures</li>
-                    <li value="4">Bonding Modes and Procedures
-                      <ol>
-                        <li value="4"><dfn>LE Bonding Procedure</dfn></li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="10">Security Aspects &mdash; LE Physical Transport
-                  <ol>
-                    <li value="7"><dfn>Privacy Feature</dfn></li>
-                    <li value="8">Random Device Address
-                      <ol>
-                        <li value="1"><dfn>Static Address</dfn></li>
-                        <li value="2"><dfn>Private address</dfn>
-                          <ol>
-                            <li value="3">
-                              <dfn>Resolvable Private Address Resolution Procedure</dfn>
-                            </li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="11"><dfn>Advertising Data</dfn> and Scan Response Data Format
-                  (defines <dfn>AD structure</dfn>)
-                </li>
-                <li value="15">Bluetooth Device Requirements
-                  <ol>
-                    <li value="1">Bluetooth Device Address (defines <dfn>BD_ADDR</dfn>)
-                      <ol>
-                        <li value="1">Bluetooth Device Address Types
-                          <ol>
-                            <li value="1"><dfn>Public Bluetooth Address</dfn></li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="16">Definitions
-                  (defines <dfn>bond</dfn>)
-                </li>
-              </ol>
-            </li>
-            <li value="6">Attribute Protocol (ATT)
-              <ol>
-                <li value="3">Protocol Requirements
-                  <ol>
-                    <li value="2">Basic Concepts
-                      <ol>
-                        <li value="1"><dfn>Attribute Type</dfn></li>
-                        <li value="2"><dfn>Attribute Handle</dfn></li>
-                        <li value="9"><dfn>Long Attribute Values</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="4">Attribute Protocol Pdus
-                      <ol>
-                        <li value="1">Error Handling
-                          <ol>
-                            <li value="1"><dfn>Error Response</dfn></li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li value="7"><dfn lt="Generic Attribute Profile|GATT">Generic Attribute Profile</dfn> (GATT)
-              <ol>
-                <li value="2">Profile Overview
-                  <ol>
-                    <li value="2">Configurations and Roles
-                      (defines <dfn>GATT Client</dfn> and <dfn>GATT Server</dfn>)
-                    </li>
-                    <li value="4">
-                      <dfn>Profile Fundamentals</dfn>,
-                      defines the <dfn>ATT Bearer</dfn>
-                    </li>
-                    <li value="5">Attribute Protocol
-                      <ol>
-                        <li value="2"><dfn>Attribute Caching</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="6"><dfn>GATT Profile Hierarchy</dfn>
-                      <ol>
-                        <li value="2"><dfn>Service</dfn></li>
-                        <li value="3"><dfn>Included Service</dfn>s</li>
-                        <li value="4"><dfn>Characteristic</dfn></li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="3"><dfn>Service Interoperability Requirements</dfn>
-                  <ol>
-                    <li value="1"><dfn>Service Definition</dfn></li>
-                    <li value="3">Characteristic Definition
-                      <ol>
-                        <li value="1">Characteristic Declaration
-                          <ol>
-                            <li value="1"><dfn>Characteristic Properties</dfn></li>
-                          </ol>
-                        </li>
-                        <li value="3">Characteristic <dfn>Descriptor</dfn> Declarations
-                          <ol>
-                            <li value="1"><dfn>Characteristic Extended Properties</dfn></li>
-                            <li value="3"><dfn>Client Characteristic Configuration</dfn></li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="4">GATT Feature Requirements &mdash; defines the
-                  <dfn lt="GATT procedure|GATT procedures">GATT procedures</dfn>.
-                  <ol>
-                    <li value="3">Server Configuration
-                      <ol>
-                        <li value="1"><dfn>Exchange MTU</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="4"><dfn>Primary Service Discovery</dfn>
-                      <ol>
-                        <li value="1">Discover All Primary Services</li>
-                        <li value="2"><dfn>Discover Primary Service by Service UUID</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="5"><dfn>Relationship Discovery</dfn>
-                      <ol>
-                        <li value="1">Find Included Services</li>
-                      </ol>
-                    </li>
-                    <li value="6"><dfn>Characteristic Discovery</dfn>
-                      <ol>
-                        <li value="1">Discover All Characteristics of a Service</li>
-                        <li value="2"><dfn>Discover Characteristics by UUID</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="7"><dfn>Characteristic Descriptor Discovery</dfn>
-                      <ol>
-                        <li value="1"><dfn>Discover All Characteristic Descriptors</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="8"><dfn>Characteristic Value Read</dfn></li>
-                    <li value="9"><dfn>Characteristic Value Write</dfn>
-                      <ol>
-                        <li value="1"><dfn>Write Without Response</dfn></li>
-                        <li value="2"><dfn>Write Characteristic Value</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="10"><dfn>Characteristic Value Notification</dfn></li>
-                    <li value="11"><dfn>Characteristic Value Indications</dfn></li>
-                    <li value="12"><dfn>Characteristic Descriptors</dfn>
-                      <ol>
-                        <li value="1"><dfn>Read Characteristic Descriptors</dfn></li>
-                        <li value="2"><dfn>Read Long Characteristic Descriptors</dfn></li>
-                        <li value="3"><dfn>Write Characteristic Descriptors</dfn></li>
-                        <li value="4"><dfn>Write Long Characteristic Descriptors</dfn></li>
-                      </ol>
-                    </li>
-                    <li value="14"><dfn local-lt="procedure times out">Procedure Timeouts</dfn></li>
-                  </ol>
-                </li>
-                <li value="6"><dfn>GAP Interoperability Requirements</dfn>
-                  <ol>
-                    <li value="1">BR/EDR GAP Interoperability Requirements
-                      <ol>
-                        <li value="1">Connection Establishment</li>
-                      </ol>
-                    </li>
-                    <li value="2">LE GAP Interoperability Requirements
-                      <ol>
-                        <li value="1">Connection Establishment</li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="7">Defined Generic Attribute Profile Service
-                  <ol>
-                    <li value="1"><dfn>Service Changed</dfn></li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li value="8">Security Manager Specification
-              <ol>
-                <li value="2">Security Manager
-                  <ol>
-                    <li value="4">Security in Bluetooth Low Energy
-                      <ol>
-                        <li value="1"><dfn>Definition of Keys and Values</dfn>,
-                          defines the
-                          <dfn lt="Identity Resolving Key|IRK">Identity Resolving Key</dfn>
-                          (<abbr title="Identity Resolving Key">IRK</abbr>)
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-        <li value="6">Core System Package [Low Energy Controller volume]
-          <ol type="A">
-            <li value="2">Link Layer Specification
-              <ol>
-                <li value="1">General Description
-                  <ol>
-                    <li value="3">Device Address
-                      <ol>
-                        <li value="1"><dfn>Public Device Address</dfn></li>
-                        <li value="2">Random Device Address
-                          <ol>
-                            <li value="1"><dfn>Static Device Address</dfn></li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li value="4">Air Interface Protocol
-                  <ol>
-                    <li value="4">Non-Connected States
-                      <ol>
-                        <li value="3">Scanning State
-                          <ol>
-                            <li value="1"><dfn>Passive Scanning</dfn></li>
-                          </ol>
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-      </ol>
-    </dd>
-    <dt>[[!BLUETOOTH-SUPPLEMENT6]]</dt>
-    <dd>
-      <ol type="A">
-        <li value="1">Data Types Specification
-          <ol>
-            <li value="1">Data Types Definitions and Formats
-              <!-- The section names here are really general, so I've added
-                   "Data Type" to some. -->
-              <ol>
-                <li value="1"><dfn local-lt="Service UUIDs">Service UUID Data Type</dfn></li>
-                <li value="2"><dfn>Local Name Data Type</dfn></li>
-                <li value="3"><dfn>Flags Data Type</dfn>
-                  (defines the <dfn>Discoverable Mode</dfn> flags)</li>
-                <li value="4"><dfn>Manufacturer Specific Data</dfn></li>
-                <li value="5"><dfn>TX Power Level</dfn></li>
-                <li value="11"><dfn>Service Data</dfn></li>
-                <li value="12"><dfn>Appearance</dfn></li>
-              </ol>
-            </li>
-          </ol>
-        </li>
-      </ol>
-    </dd>
-  </dl>
+  </dd>
+  <dt>[[!BLUETOOTH-SUPPLEMENT6]]</dt>
+  <dd>
+    <ol type="A">
+      <li value="1">Data Types Specification
+        <ol>
+          <li value="1">Data Types Definitions and Formats
+            <!-- The section names here are really general, so I've added
+                  "Data Type" to some. -->
+            <ol>
+              <li value="1"><dfn local-lt="Service UUIDs">Service UUID Data Type</dfn></li>
+              <li value="2"><dfn>Local Name Data Type</dfn></li>
+              <li value="3"><dfn>Flags Data Type</dfn>
+                (defines the <dfn>Discoverable Mode</dfn> flags)</li>
+              <li value="4"><dfn>Manufacturer Specific Data</dfn></li>
+              <li value="5"><dfn>TX Power Level</dfn></li>
+              <li value="11"><dfn>Service Data</dfn></li>
+              <li value="12"><dfn>Appearance</dfn></li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+  </dd>
+</dl>
 </section>

--- a/index.bs
+++ b/index.bs
@@ -2407,13 +2407,13 @@ them again when it re-connects.
 
 ### The Bluetooth cache ### {#bluetooth-cache}
 
-The UA MUST maintain a <a>Bluetooth cache</a> of the hierarchy of Services,
-Characteristics, and Descriptors it has discovered on a device. The UA MAY share
-this cache between multiple origins accessing the same device. Each potential
-entry in the cache is either known-present, known-absent, or unknown. The cache
-MUST NOT contain two entries that are for the <a>same attribute</a>. Each
-known-present entry in the cache is associated with an optional
-<code>Promise&lt;{{BluetoothRemoteGATTService}}></code>,
+The UA MUST maintain a <dfn for="Bluetooth cache">Bluetooth cache</dfn> of the
+hierarchy of Services, Characteristics, and Descriptors it has discovered on a
+device. The UA MAY share this cache between multiple origins accessing the same
+device. Each potential entry in the cache is either known-present, known-absent,
+or unknown. The cache MUST NOT contain two entries that are for the <a>same
+attribute</a>. Each known-present entry in the cache is associated with an
+optional <code>Promise&lt;{{BluetoothRemoteGATTService}}></code>,
 <code>Promise&lt;{{BluetoothRemoteGATTCharacteristic}}></code>, or
 <code>Promise&lt;{{BluetoothRemoteGATTDescriptor}}></code> instance for each
 {{Bluetooth}} instance.
@@ -3589,10 +3589,11 @@ following steps:
 <div class="unstable">
 ### Bluetooth Tree ### {#bluetooth-tree}
 
+The <dfn for="Bluetooth tree">Bluetooth tree</dfn> is the name given to
 {{Navigator/bluetooth|navigator.bluetooth}} and objects implementing the
 {{BluetoothDevice}}, {{BluetoothRemoteGATTService}},
 {{BluetoothRemoteGATTCharacteristic}}, or {{BluetoothRemoteGATTDescriptor}}
-interface <a>participate in a tree</a>, simply named the <a>Bluetooth tree</a>.
+interface <a>participate in a tree</a>.
 
 * The <a>children</a> of {{Navigator/bluetooth|navigator.bluetooth}}</code></a>
     are the {{BluetoothDevice}} objects representing devices in the


### PR DESCRIPTION
This change updates the spec source file to use more Markdown syntax in
order to improve readability. This commit updates Sections 6 to 9 of the
spec. Most of Section 9 still maintains its list in HTML, since it uses
specific numbering and lists with letters.

The following changes were performed:

* Heading tags were replaced with their Markdown equivalent, `#`.
* `<p>` tags were removed.
* `<ol>`, `<ul>`, and `<li>` tags were replaced with their Markdown
    equivalent, `*` and `1.`.
* `<table>` tags had the `data` class removed to fix their rendering
    such that they don't overflow past their containers.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/473.html" title="Last updated on Feb 13, 2020, 6:55 PM UTC (fe20294)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/473/7610a77...odejesush:fe20294.html" title="Last updated on Feb 13, 2020, 6:55 PM UTC (fe20294)">Diff</a>