### PR TITLE
Mark GATT descriptors as stable

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3061,8 +3061,7 @@ parallel</a>.
 
 </div>
 
-<div algorithm="BluetoothRemoteGATTCharacteristic getDescriptor"
-    class="unstable">
+<div algorithm="BluetoothRemoteGATTCharacteristic getDescriptor">
 The <code><dfn method for="BluetoothRemoteGATTCharacteristic">
 getDescriptor(<var>descriptor</var>)</dfn></code> method retrieves a
 <a>Descriptor</a> inside this Characteristic. When invoked, it MUST return
@@ -3075,8 +3074,7 @@ getDescriptor(<var>descriptor</var>)</dfn></code> method retrieves a
 >   <i>child type</i>="GATT Descriptor")</span>
 </div>
 
-<div algorithm="BluetoothRemoteGATTCharacteristic getDescriptors"
-    class="unstable">
+<div algorithm="BluetoothRemoteGATTCharacteristic getDescriptors">
 The <code><dfn method for="BluetoothRemoteGATTCharacteristic">
 getDescriptors(<var>descriptor</var>)</dfn></code> method retrieves a list of
 <a>Descriptor</a>s inside this Characteristic. When invoked, it MUST return
@@ -3431,7 +3429,6 @@ promise</a> <var>promise</var> and run the following steps <a>in parallel</a>:
 
 </div>
 
-<div class="unstable">
 ## BluetoothRemoteGATTDescriptor ## {#bluetoothgattdescriptor-interface}
 
 {{BluetoothRemoteGATTDescriptor}} represents a GATT <a>Descriptor</a>, which
@@ -3583,7 +3580,6 @@ following steps:
             {{ArrayBuffer}} containing <var>bytes</var>.
         1. <a>Resolve</a> <var>promise</var> with <code>undefined</code>.
 
-</div>
 </div>
 
 ## Events ## {#events}


### PR DESCRIPTION
The algorithms related to GATT descriptos have been implemented in
Chromium, therefore they are stable now. The following have been marked
as stable:
* BluetoothRemoteGATTCharacteristic getDescriptor algorithm
* BluetoothRemoteGATTCharacteristic getDescriptors algorithm
* BluetoothRemoteGATTDescriptor interface
* BluetoothRemoteGATTDescriptor create algorithm
* BluetoothRemoteGATTDescriptor readValue algorithm
* BluetoothRemoteGATTDescriptor writeValue algorithm

See
https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/bluetooth/
for Chromium implementation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/475.html" title="Last updated on Feb 13, 2020, 7:31 PM UTC (fca6873)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/475/62f00d7...odejesush:fca6873.html" title="Last updated on Feb 13, 2020, 7:31 PM UTC (fca6873)">Diff</a>