### PR TITLE
Fix race condition in {,un}watchAdvertisements()

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -4,11 +4,15 @@ set -e # Exit with nonzero exit code if anything fails.
 SOURCE_BRANCH="master"
 TARGET_BRANCH="gh-pages"
 
+COLOR_RED="\e[31m"
+COLOR_DEFAULT="\e[39m"
+
 for SPEC in $SPECS; do
-  echo ${SPEC}.bs:
+  echo "Parsing ${SPEC}.bs:"
   ERR=$(curl https://api.csswg.org/bikeshed/ -f -F file=@${SPEC}.bs -F output=err)
   if [ -n "$ERR" ]; then
-    echo "$ERR"
+    echo -e "${COLOR_RED}Error occurred while parsing ${SPEC}.bs:${COLOR_DEFAULT}"
+    echo -e "$ERR"
     exit 1
   fi
 done

--- a/index.bs
+++ b/index.bs
@@ -2113,7 +2113,7 @@ following steps:
     1. [=Queue a task=] to perform the following steps:
         1. Set <code>this.{{watchingAdvertisements}}</code> to `true`.
         1. Resolve |promise| with `undefined`.
-1. [=If aborted=], reject |promise| with {{InvalidStateError}}.
+1. [=If aborted=], reject |promise| with {{AbortError}}.
 
 <div class="note">
 Scanning costs power, so websites should avoid watching for advertisements

--- a/index.bs
+++ b/index.bs
@@ -2090,7 +2090,7 @@ method, when invoked, MUST return <a>a new promise</a> |promise| and run the
 following steps <a>in parallel</a>:
 
 1. If <code>this.{{watchingAdvertisements}}</code> is `true`, resolve |promise|
-    with `undefined`.
+    with `undefined` and abort these steps.
 1. Ensure that the UA is scanning for this device's advertisements. The UA
     SHOULD NOT filter out "duplicate" advertisements for the same device.
 1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of the
@@ -2121,7 +2121,7 @@ as soon as possible.
 The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code>
 method, when invoked, MUST run the following steps:
 
-1. If <code>this.{{watchingAdvertisements}}</code> is `false`, return.
+1. If <code>this.{{watchingAdvertisements}}</code> is `false`, abort these steps.
 1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
 1. If no more {{BluetoothDevice}}s in the whole UA have
     {{watchingAdvertisements}} set to `true`, the UA SHOULD stop scanning for

--- a/index.bs
+++ b/index.bs
@@ -2086,27 +2086,30 @@ attribute MUST perform the following steps:
 
 <div algorithm="watchAdvertisements" class="unstable">
 The <code><dfn method for="BluetoothDevice">watchAdvertisements()</dfn></code>
-method, when invoked, MUST return <a>a new promise</a> |promise| and run the
-following steps <a>in parallel</a>:
+method, when invoked, MUST return <a>a new promise</a> |promise| and
+let |watchAdvertisementsQueue| be the result of
+<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">
+starting a new parallel queue</a>:
 
-1. If <code>this.{{watchingAdvertisements}}</code> is `true`, resolve |promise|
-    with `undefined` and abort these steps.
-1. Ensure that the UA is scanning for this device's advertisements. The UA
-    SHOULD NOT filter out "duplicate" advertisements for the same device.
-1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of the
-    following errors, and abort these steps:
+1. <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">
+    Enqueue the following steps</a> to |watchAdvertisementsQueue|:
+    1. If a <code>{{unwatchAdvertisements()}}</code> task is enqueued in
+        |watchAdvertisementsQueue| reject |promise| with {{InvalidStateError}}.
+    1. Ensure that the UA is scanning for this device's advertisements. The UA
+        SHOULD NOT filter out "duplicate" advertisements for the same device.
+    1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of
+        the following errors, and abort these steps:
 
-    <dl class="switch">
-      <dt>The UA doesn't support scanning for advertisements</dt>
-      <dd>{{NotSupportedError}}</dd>
+        <dl class="switch">
+          <dt>The UA doesn't support scanning for advertisements</dt>
+          <dd>{{NotSupportedError}}</dd>
 
-      <dt>Bluetooth is turned off</dt>
-      <dd>{{InvalidStateError}}</dd>
+          <dt>Bluetooth is turned off</dt>
+          <dd>{{InvalidStateError}}</dd>
 
-      <dt>Other reasons</dt>
-      <dd>{{UnknownError}}</dd>
-    </dl>
-1. <a>Queue a task</a> to perform the following steps:
+          <dt>Other reasons</dt>
+          <dd>{{UnknownError}}</dd>
+        </dl>
     1. Set <code>this.{{watchingAdvertisements}}</code> to `true`.
     1. Resolve |promise| with `undefined`.
 
@@ -2119,9 +2122,12 @@ as soon as possible.
 
 <div algorithm="unwatchAdvertisements" class="unstable">
 The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code>
-method, when invoked, MUST run the following steps:
+method, when invoked, MUST let |watchAdvertisementsQueue| be the result of
+<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">
+starting a new parallel queue</a>:
 
-1. If <code>this.{{watchingAdvertisements}}</code> is `false`, abort these steps.
+1. <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">
+    Enqueue the following steps</a> to |watchAdvertisementsQueue|:
 1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
 1. If no more {{BluetoothDevice}}s in the whole UA have
     {{watchingAdvertisements}} set to `true`, the UA SHOULD stop scanning for

--- a/index.bs
+++ b/index.bs
@@ -2089,6 +2089,8 @@ The <code><dfn method for="BluetoothDevice">watchAdvertisements()</dfn></code>
 method, when invoked, MUST return <a>a new promise</a> |promise| and run the
 following steps <a>in parallel</a>:
 
+1. If <code>this.{{watchingAdvertisements}}</code> is `true`, resolve |promise|
+    with `undefined`.
 1. Ensure that the UA is scanning for this device's advertisements. The UA
     SHOULD NOT filter out "duplicate" advertisements for the same device.
 1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of the
@@ -2119,6 +2121,7 @@ as soon as possible.
 The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code>
 method, when invoked, MUST run the following steps:
 
+1. If <code>this.{{watchingAdvertisements}}</code> is `false`, return.
 1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
 1. If no more {{BluetoothDevice}}s in the whole UA have
     {{watchingAdvertisements}} set to `true`, the UA SHOULD stop scanning for

--- a/index.bs
+++ b/index.bs
@@ -529,6 +529,7 @@ that UAs will choose not to prompt.
     attribute EventHandler onavailabilitychanged;
     [SameObject]
     readonly attribute BluetoothDevice? referringDevice;
+    Promise<sequence<BluetoothDevice>> getDevices();
     Promise<BluetoothDevice> requestDevice(optional RequestDeviceOptions options = {});
   };
 
@@ -538,10 +539,11 @@ that UAs will choose not to prompt.
 </xmp>
 
 <div class="note" heading="{{Bluetooth}} members">
-Note: {{Bluetooth/getAvailability()}} informs the page whether Bluetooth is available
-at all. An adapter that's disabled through software should count as available.
-Changes in availability, for example when the user physically attaches or
-detaches an adapter, are reported through the {{availabilitychanged}} event.
+Note: {{Bluetooth/getAvailability()}} informs the page whether Bluetooth is
+available at all. An adapter that's disabled through software should count as
+available. Changes in availability, for example when the user physically
+attaches or detaches an adapter, are reported through the
+{{availabilitychanged}} event.
 
 <p class="unstable">
   {{Bluetooth/referringDevice}} gives access to the device from which the user
@@ -550,6 +552,11 @@ detaches an adapter, are reported through the {{availabilitychanged}} event.
   might advertise a URL, which the UA allows the user to open. A
   {{BluetoothDevice}} representing the beacon would be available through
   <code>navigator.bluetooth.{{referringDevice}}</code>.
+</p>
+
+<p class="unstable">
+  {{Bluetooth/getDevices()}} enables the page to retrieve Bluetooth devices that
+  the user has granted access to.
 </p>
 
 {{Bluetooth/requestDevice(options)}} asks the user to grant this origin access
@@ -659,6 +666,15 @@ On the other hand, if the website calls
 the dialog will contain devices D1, D2, and D3, and if the user selects D1, the
 website will be able to access services A, B, C, and D.
 
+If the website then calls
+
+<pre highlight="js">
+  navigator.bluetooth.getDevices();
+</pre>
+
+the resulting {{Promise}} will resolve into an array containing device D1, and
+the website will be able to access services A, B, C, and D.
+
 The <code>optionalServices</code> list doesn't add any devices to the dialog the
 user sees, but it does affect which services the website can use from the device
 the user picks.
@@ -673,6 +689,16 @@ the user picks.
 Shows a dialog containing D1 and D2, but not D4, since D4 doesn't contain the
 required services. If the user selects D2, unlike in the first example, the
 website will be able to access services A, B, and E.
+
+If the website calls
+
+<pre highlight="js">
+  navigator.bluetooth.getDevices();
+</pre>
+
+again, then the resulting {{Promise}} will resolve into an array containing the
+devices D1 and D2. The A, B, C, and D services will be accessible on device D1,
+while A, B, and E services will be accessible on device D2.
 
 The allowed services also apply if the device changes after the user grants
 access. For example, if the user selects D1 in the previous
@@ -1144,6 +1170,31 @@ a {{BluetoothDataFilterInit}} |filter| if the following steps return `match`.
   cause delays, so this spec doesn't require it.
 </div>
 
+<div algorithm="getDevice invocation">
+To <code><dfn method for="Bluetooth">getDevices()</dfn></code> method, when
+invoked and given a {{BluetoothPermissionStorage}} |storage|, MUST return
+[=a new promise=] |promise| and run the following steps [=in parallel=]:
+
+1. Let |devices| be a new empty {{Array}}.
+1. For each |allowedDevice| in
+    <code>|storage|.{{BluetoothPermissionStorage/allowedDevices}}</code>, add
+    the {{BluetoothDevice}} object representing |allowedDevice|@{{[[device]]}}
+    to |devices|.
+1. [=Resolve=] |promise| with |devices|.
+
+    <div class="note unstable">
+      Note: The {{BluetoothDevice}}s in |devices| may not be in range of the
+      Bluetooth radio. For a given |device| in |devices|, the
+      {{BluetoothDevice/watchAdvertisements()}} method can be used to observe
+      when |device| is in range and broadcasting advertisement packets. When an
+      {{advertisementreceived}} event |event| is fired on a |device|, it may
+      indicate that it is close enough for a connection to be established by
+      calling
+      <code>|event|.device.gatt.{{BluetoothRemoteGATTServer/connect()}}</code>.
+    </div>
+
+</div>
+
 <div algorithm="requestDevice invocation">
 The <code><dfn method for="Bluetooth">requestDevice(<var>options</var>)
 </dfn></code> method, when invoked, MUST return <a>a new promise</a> |promise|
@@ -1174,7 +1225,8 @@ and run the following steps <a>in parallel</a>:
 </div>
 
 <div algorithm="requesting a Bluetooth device">
-To <dfn>request Bluetooth devices</dfn>, given a sequence of
+To <dfn>request Bluetooth devices</dfn>, given a
+{{BluetoothPermissionStorage}} |storage| and a sequence of
 {{BluetoothLEScanFilterInit}}s, |filters|, which can be `null` to represent that
 all devices can match, and a sequence of {{BluetoothServiceUUID}}s,
 |optionalServices|, the UA MUST run the following steps:
@@ -1255,11 +1307,12 @@ all devices can match, and a sequence of {{BluetoothServiceUUID}}s,
       to indicate interest and then perform a privacy-disabled scan to retrieve
       the name.
     </div>
+1. The UA MAY <a>add |device| to |storage|</a>.
 
     <div class="note">
       Note: Choosing a |device| probably indicates that the user
       intends that device to appear in the
-      {{BluetoothPermissionData/allowedDevices}} list of {{"bluetooth"}}'s
+      {{BluetoothPermissionStorage/allowedDevices}} list of {{"bluetooth"}}'s
       <a>extra permission data</a> for at least the <a>current settings
       object</a>, for its {{AllowedBluetoothDevice/mayUseGATT}} field to be
       `true`, and for all the services in the union of
@@ -1471,6 +1524,35 @@ following steps:
 Issue: We need a way for a site to register to receive an event when an interesting
 device comes within range.
 
+<div algorithm="add Bluetooth device to storage">
+To <dfn data-lt="add device to storage">add an allowed
+[=Bluetooth device=]</dfn> |device| to {{BluetoothPermissionStorage}} |storage|
+given a set of |requiredServiceUUIDs| and a set of |optionalServiceUUIDs|, the
+UA MUST run the following steps:
+
+1. Let |grantedServiceUUIDs| be a new {{Set}}.
+1. Add the contents of |requiredServiceUUIDs| to |grantedServiceUUIDs|.
+1. Add the contents of |optionalServiceUUIDs| to |grantedServiceUUIDs|.
+1. Search for an element |allowedDevice| in
+    <code>|storage|.{{BluetoothPermissionStorage/allowedDevices}}</code> where
+    |device| is equal to <code>|allowedDevice|@{{[[device]]}}</code>. If one is
+    found, perform the following sub-steps:
+    1. Add the contents of
+        <code>|allowedDevice|.{{AllowedBluetoothDevice/allowedServices}}</code>
+        to |grantedServiceUUIDs|.
+
+    If one is not found, perform the following sub-steps:
+    1. Let |allowedDevice|.{{AllowedBluetoothDevice/deviceId}} be a unique ID to
+        the extent that the UA can determine that two Bluetooth connections are
+        the same device and to the extent that the
+        <a href="#note-device-id-tracking">user wants to expose that fact to
+        script</a>.
+1. Set |allowedDevice|.{{AllowedBluetoothDevice/allowedServices}} to
+    |grantedServiceUUIDs|.
+1. Set |allowedDevice|.{{AllowedBluetoothDevice/mayUseGATT}} to `true`.
+
+</div>
+
 <div class="unstable">
 ## Permission API Integration ## {#permission-api-integration}
 
@@ -1543,7 +1625,7 @@ feature</a>'s permission-related algorithms and types are defined as follows:
 
   <dt><a>extra permission data type</a></dt>
   <dd>
-    {{BluetoothPermissionData}}, defined as:
+    {{BluetoothPermissionStorage}}, defined as:
     
     <xmp class="idl">
       dictionary AllowedBluetoothDevice {
@@ -1552,7 +1634,7 @@ feature</a>'s permission-related algorithms and types are defined as follows:
         // An allowedServices of "all" means all services are allowed.
         required (DOMString or sequence<UUID>) allowedServices;
       };
-      dictionary BluetoothPermissionData {
+      dictionary BluetoothPermissionStorage {
         required sequence<AllowedBluetoothDevice> allowedDevices;
       };
     </xmp>
@@ -1564,7 +1646,7 @@ feature</a>'s permission-related algorithms and types are defined as follows:
 
   <dt><a>extra permission data constraints</a></dt>
   <dd>
-    Distinct elements of {{BluetoothPermissionData/allowedDevices}} must have
+    Distinct elements of {{BluetoothPermissionStorage/allowedDevices}} must have
     different {{AllowedBluetoothDevice/[[device]]}}s and different
     {{AllowedBluetoothDevice/deviceId}}s.
 
@@ -1642,9 +1724,9 @@ feature</a>'s permission-related algorithms and types are defined as follows:
         <code>|status|.devices</code> to an empty {{FrozenArray}} and abort
         these steps.
     1. Let <var>matchingDevices</var> be a new {{Array}}.
-    1. Let |data|, a {{BluetoothPermissionData}}, be {{"bluetooth"}}'s <a>extra
-        permission data</a> for the <a>current settings object</a>.
-    1. For each |allowedDevice| in <code>|data|.allowedDevices</code>, run the
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{"bluetooth"}}'s
+        <a>extra permission data</a> for the <a>current settings object</a>.
+    1. For each |allowedDevice| in <code>|storage|.allowedDevices</code>, run the
         following sub-steps:
         1. If <code><var>desc</var>.deviceId</code> is set and
             <code><var>allowedDevice</var>.deviceId !=
@@ -1676,12 +1758,12 @@ feature</a>'s permission-related algorithms and types are defined as follows:
     To <dfn>revoke Bluetooth access</dfn> to devices the user no longer intends to expose,
     the UA MUST run the following steps:
 
-    1. Let |data|, a {{BluetoothPermissionData}}, be {{"bluetooth"}}'s <a>extra
-        permission data</a> for the <a>current settings object</a>.
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{"bluetooth"}}'s
+        <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each {{BluetoothDevice}} instance |deviceObj| in the <a>current
         realm</a>, run the following sub-steps:
         1. If there is an {{AllowedBluetoothDevice}} |allowedDevice| in
-            <code>|data|.{{allowedDevices}}</code> such that:
+            <code>|storage|.{{allowedDevices}}</code> such that:
 
             * <code>|allowedDevice|.{{[[device]]}}</code> is the <a>same
                 device</a> as
@@ -1955,9 +2037,9 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 <a>Bluetooth device</a> <var>device</var> inside a {{Bluetooth}} instance
 <var>context</var>, the UA MUST run the following steps:
 
-1. Let |data|, a {{BluetoothPermissionData}}, be {{"bluetooth"}}'s <a>extra
-    permission data</a> for the <a>current settings object</a>.
-1. Find the |allowedDevice| in <code>|data|.{{allowedDevices}}</code> with
+1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{"bluetooth"}}'s
+    <a>extra permission data</a> for the <a>current settings object</a>.
+1. Find the |allowedDevice| in <code>|storage|.{{allowedDevices}}</code> with
     <code><var>allowedDevice</var>.{{[[device]]}}</code> the <a>same device</a>
     as <var>device</var>. If there is no such object, throw a {{SecurityError}}
     and abort these steps.
@@ -1993,7 +2075,7 @@ attribute MUST perform the following steps:
 
 1. If {{"bluetooth"}}'s <a>extra permission data</a> for `this`'s <a>relevant
     settings object</a> has an {{AllowedBluetoothDevice}} |allowedDevice| in its
-    {{BluetoothPermissionData/allowedDevices}} list with
+    {{BluetoothPermissionStorage/allowedDevices}} list with
     <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code> the
     <a>same device</a> as <code>this.{{[[representedDevice]]}}</code> and
     <code>|allowedDevice|.{{AllowedBluetoothDevice/mayUseGATT}}</code> equal to
@@ -3595,7 +3677,7 @@ interface <a>participate in a tree</a>.
 
 * The <a>children</a> of {{Navigator/bluetooth|navigator.bluetooth}}</code></a>
     are the {{BluetoothDevice}} objects representing devices in the
-    {{BluetoothPermissionData/allowedDevices}} list in {{"bluetooth"}}'s
+    {{BluetoothPermissionStorage/allowedDevices}} list in {{"bluetooth"}}'s
     <a>extra permission data</a> for
     {{Navigator/bluetooth|navigator.bluetooth}}'s <a>relevant settings
     object</a>, in an unspecified order.

--- a/index.bs
+++ b/index.bs
@@ -2090,10 +2090,11 @@ the result of [=starting a new parallel queue=].
 <div algorithm="watchAdvertisements" class="unstable">
 The <code><dfn method for="BluetoothDevice">watchAdvertisements()</dfn></code>
 method, when invoked, MUST return <a>a new promise</a> |promise| and run the
-follwing steps:
+following steps:
 
 1. [=parallel queue/Enqueue the following steps=] to the [=watch advertisements
-    manager=]:
+    manager=], but [=abort when=] <code>this.{{unwatchAdvertisements()}}</code>
+    is called:
     1. Ensure that the UA is scanning for this device's advertisements. The UA
         SHOULD NOT filter out "duplicate" advertisements for the same device.
     1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of
@@ -2112,6 +2113,7 @@ follwing steps:
     1. [=Queue a task=] to perform the following steps:
         1. Set <code>this.{{watchingAdvertisements}}</code> to `true`.
         1. Resolve |promise| with `undefined`.
+1. [=If aborted=], reject |promise| with {{InvalidStateError}}.
 
 <div class="note">
 Scanning costs power, so websites should avoid watching for advertisements
@@ -2124,6 +2126,7 @@ as soon as possible.
 The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code>
 method, when invoked, MUST run the following steps:
 
+1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
 1. [=parallel queue/Enqueue the following step=] to [=watch advertisements
     manager=]:
     1. If no more {{BluetoothDevice}}s in the whole UA have
@@ -2132,7 +2135,6 @@ method, when invoked, MUST run the following steps:
         representing the same device as `this` have {{watchingAdvertisements}}
         set to `true`, the UA SHOULD reconfigure the scan to avoid receiving
         reports for this device.
-1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2084,17 +2084,16 @@ attribute MUST perform the following steps:
 
 </div>
 
+A user agent has an associated <dfn>watch advertisements manager</dfn> which is
+the result of [=starting a new parallel queue=].
+
 <div algorithm="watchAdvertisements" class="unstable">
 The <code><dfn method for="BluetoothDevice">watchAdvertisements()</dfn></code>
-method, when invoked, MUST return <a>a new promise</a> |promise| and
-let |watchAdvertisementsQueue| be the result of
-<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">
-starting a new parallel queue</a>:
+method, when invoked, MUST return <a>a new promise</a> |promise| and run the
+follwing steps:
 
-1. <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">
-    Enqueue the following steps</a> to |watchAdvertisementsQueue|:
-    1. If a <code>{{unwatchAdvertisements()}}</code> task is enqueued in
-        |watchAdvertisementsQueue| reject |promise| with {{InvalidStateError}}.
+1. [=parallel queue/Enqueue the following steps=] to the [=watch advertisements
+    manager=]:
     1. Ensure that the UA is scanning for this device's advertisements. The UA
         SHOULD NOT filter out "duplicate" advertisements for the same device.
     1. If the UA fails to enable scanning, <a>reject</a> |promise| with one of
@@ -2110,8 +2109,9 @@ starting a new parallel queue</a>:
           <dt>Other reasons</dt>
           <dd>{{UnknownError}}</dd>
         </dl>
-    1. Set <code>this.{{watchingAdvertisements}}</code> to `true`.
-    1. Resolve |promise| with `undefined`.
+    1. [=Queue a task=] to perform the following steps:
+        1. Set <code>this.{{watchingAdvertisements}}</code> to `true`.
+        1. Resolve |promise| with `undefined`.
 
 <div class="note">
 Scanning costs power, so websites should avoid watching for advertisements
@@ -2122,18 +2122,17 @@ as soon as possible.
 
 <div algorithm="unwatchAdvertisements" class="unstable">
 The <code><dfn method for="BluetoothDevice">unwatchAdvertisements()</dfn></code>
-method, when invoked, MUST let |watchAdvertisementsQueue| be the result of
-<a href="https://html.spec.whatwg.org/multipage/infrastructure.html#starting-a-new-parallel-queue">
-starting a new parallel queue</a>:
+method, when invoked, MUST run the following steps:
 
-1. <a href="https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">
-    Enqueue the following steps</a> to |watchAdvertisementsQueue|:
+1. [=parallel queue/Enqueue the following step=] to [=watch advertisements
+    manager=]:
+    1. If no more {{BluetoothDevice}}s in the whole UA have
+        {{watchingAdvertisements}} set to `true`, the UA SHOULD stop scanning
+        for advertisements. Otherwise, if no more {{BluetoothDevice}}s
+        representing the same device as `this` have {{watchingAdvertisements}}
+        set to `true`, the UA SHOULD reconfigure the scan to avoid receiving
+        reports for this device.
 1. Set <code>this.{{watchingAdvertisements}}</code> to `false`.
-1. If no more {{BluetoothDevice}}s in the whole UA have
-    {{watchingAdvertisements}} set to `true`, the UA SHOULD stop scanning for
-    advertisements. Otherwise, if no more {{BluetoothDevice}}s representing the
-    same device as `this` have {{watchingAdvertisements}} set to `true`, the UA
-    SHOULD reconfigure the scan to avoid receiving reports for this device.
 
 </div>
 


### PR DESCRIPTION
This change updates the algorithms for `watchAdvertisements()` and `unwatchAdvertisements()` to use the same parallel queue in order to prevent a race condition from happening when sending instructions to the OS to start/stop Bluetooth discovery for the device.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: write EPROTO 139705468127104:error:1407742E:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert protocol version:../deps/openssl/openssl/ssl/s23_clnt.c:772:
 :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 12, 2020, 10:01 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [HTML Diff Service](http://services.w3.org/htmldiff) - The HTML Diff Service is used to create HTML diffs of the spec changes suggested in a pull request.

:link: [Related URL](https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2FWebBluetoothCG%2Fweb-bluetooth%2Fpull%2F478%2F695d9c2.html&doc2=https%3A%2F%2Fpr-preview.s3.amazonaws.com%2Fodejesush%2Fweb-bluetooth%2Fpull%2F478.html)



_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20WebBluetoothCG/web-bluetooth%23478.)._
</details>
