### PR TITLE
Abort Bluetooth discovery when focus is lost

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2186,6 +2186,25 @@ To <dfn>abort {{BluetoothDevice/watchAdvertisements}}</dfn> for a
 </div>
 
 <div class="unstable">
+### Handling Document Loss of Full Activity ### {#handling-full-activity-loss}
+
+Operations that initiate a scan for Bluetooth devices may only run in a [=fully
+active=] [=document=]. When [=fully active|full activity=] is lost, scanning
+operations for that [=document=] need to be aborted.
+
+<div algorithm="handle full activity loss">
+When the user agent determines that a [=responsible document=] of the [=current
+settings object=] is no longer [=fully active=], it must run these steps:
+
+1. [=map/For each=] |device| in <code>{{Bluetooth}}.{{[[deviceInstanceMap]]}}
+    </code>, perform the following steps:
+    1. If |device|.watchingAdvertisements is `true`, run [=abort
+        watchAdvertisements=].
+
+</div>
+</div>
+
+<div class="unstable">
 ### Responding to Advertising Events ### {#advertising-events}
 
 When an <a>advertising event</a> arrives for a {{BluetoothDevice}}

--- a/index.bs
+++ b/index.bs
@@ -2200,7 +2200,8 @@ settings object=] is no longer [=fully active=], it must run these steps:
     <code>{{Bluetooth}}.{{[[deviceInstanceMap]]}}</code>, perform the
     following steps:
     1. If <code>|device|.{{[[watchAdvertisementsState]]}}</code> is
-        `pending-watch` or `watching`, run [=abort watchAdvertisements=].
+        `pending-watch` or `watching`, run [=abort watchAdvertisements=] with
+        |device|.
 
 </div>
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2196,10 +2196,11 @@ operations for that [=document=] need to be aborted.
 When the user agent determines that a [=responsible document=] of the [=current
 settings object=] is no longer [=fully active=], it must run these steps:
 
-1. [=map/For each=] |device| in <code>{{Bluetooth}}.{{[[deviceInstanceMap]]}}
-    </code>, perform the following steps:
-    1. If |device|.watchingAdvertisements is `true`, run [=abort
-        watchAdvertisements=].
+1. [=map/For each=] |device| in
+    <code>{{Bluetooth}}.{{[[deviceInstanceMap]]}}</code>, perform the
+    following steps:
+    1. If <code>|device|.{{[[watchAdvertisementsState]]}}</code> is
+        `pending-watch` or `watching`, run [=abort watchAdvertisements=].
 
 </div>
 </div>

--- a/scanning.bs
+++ b/scanning.bs
@@ -525,6 +525,23 @@ spec:web-bluetooth
     </div>
   </section>
 
+## Handling Document Loss of Full Activity ## {#handling-full-activity-loss}
+
+Operations that initiate a scan for Bluetooth devices may only run in a [=fully
+active=] [=document=]. When [=fully active|full activity=] is lost, scanning
+operations for that [=document=] need to be aborted.
+
+<div algorithm="handle full activity loss">
+When the user agent determines that a [=responsible document=] of the [=current
+settings object=] is no longer [=fully active=], it must run these steps:
+
+1. [=map/For each=] |activeScan| in <code>
+    navigator.bluetooth.{{[[activeScans]]}}</code>, perform the following
+    steps:
+    1. Call <code>|activeScan|.{{BluetoothLEScan/stop()}}</code>.
+
+</div>
+
   <section>
     <h3 id="permission">Permission to scan</h3>
 


### PR DESCRIPTION
This change adds a handler for loss of full activity that stops any on-going Bluetooth scans. This is to mitigate an identity risk that is present if two sites are watching for device advertisements and receive the same advertisement at the same time.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/odejesush/web-bluetooth/pull/481.html" title="Last updated on Mar 20, 2020, 5:36 PM UTC (7ce50e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/481/e8635ae...odejesush:7ce50e4.html" title="Last updated on Mar 20, 2020, 5:36 PM UTC (7ce50e4)">Diff</a>