### PR TITLE
Missing "this."

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -404,11 +404,11 @@ spec:web-bluetooth
           Use {{BluetoothLEScanOptions/acceptAllAdvertisements}} to explicitly do it.
         </li>
         <li>
-          Initialize {{BluetoothLEScanFilter/manufacturerData}} as
+          Initialize <code>this.{{BluetoothLEScanFilter/manufacturerData}}</code> as
           <code>new BluetoothManufacturerDataFilter(|init|.{{BluetoothLEScanFilterInit/manufacturerData}})</code>.
         </li>
         <li>
-          Initialize {{BluetoothLEScanFilter/serviceData}} as
+          Initialize <code>this.{{BluetoothLEScanFilter/serviceData}}</code> as
           <code>new BluetoothManufacturerDataFilter(|init|.{{BluetoothLEScanFilterInit/serviceData}})</code>.
         </li>
         <li>


### PR DESCRIPTION
For coherence with other steps.