### PR TITLE
Correct a minor error in BluetoothAdvertisingEvent's constructor algorithm

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2472,7 +2472,7 @@ constructor MUST perform the following steps:
     1. Let <var>service</var> be the result of calling
         <code>BluetoothUUID.{{BluetoothUUID/getService()|getService}}(<var>key</var>).</code>
     1. Let <var>value</var> be the value.
-    1. Set <var>value</var> is not a {{BufferSource}}, throw a {{TypeError}}.
+    1. If <var>value</var> is not a {{BufferSource}}, throw a {{TypeError}}.
     1. Let <var>bytes</var> be a new <a>read only ArrayBuffer</a> containing
         <a>a copy of the bytes held</a> by <var>value</var>.
     1. Add a mapping from <var>service</var> to <code>new


### PR DESCRIPTION
This is to make it consistent with how manufacturerData is defined


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/SinZ163/web-bluetooth/pull/491.html" title="Last updated on May 3, 2020, 4:21 AM UTC (94ec189)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/491/b8f5a20...SinZ163:94ec189.html" title="Last updated on May 3, 2020, 4:21 AM UTC (94ec189)">Diff</a>