### PR TITLE
serviceUUID does not exist in definition of BluetoothLEScanFilter

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -754,8 +754,8 @@ settings object=] is no longer [=fully active=], it must run these steps:
           and <code>|filter|.namePrefix</code> is a prefix of it.
         </li>
         <li>
-          If <code>|filter|.serviceUUID</code> is non-<code>null</code>,
-          it is equal to a <a>Service UUID</a> in |event|.
+          For each |uuid| in <code>|filter|.services</code>,
+          some <a>Service UUID</a> in |event| is equal to |uuid|.
         </li>
         <li>
           For each (|id|, |filter|) in <code>|filter|.manufacturerData</code>'s <a>map entries</a>,


### PR DESCRIPTION
I guess `serviceUUID` has been replaced by `services` (array of `UUID`) in `BluetoothLEScanFilter`. Please check this is ok before merging.