### PR TITLE
Fix example (#495)

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1848,7 +1848,7 @@ function checkAvailability() {
   });
 }
 
-navigator.permission.query({name: "bluetooth"}).then(status => {
+navigator.permissions.<a idl for="Permissions" lt="query()">query</a>({name: "bluetooth"}).then(status => {
   if (status.state !== 'denied') checkAvailability();
 
   // Bluetooth is blocked, listen for change in PermissionStatus.


### PR DESCRIPTION
I added the missing 's' from the end of `navigator.permissions`, and a link to the `query` doc.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Totati/web-bluetooth/pull/496.html" title="Last updated on May 9, 2020, 6:50 PM UTC (375fe6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/496/16d2ef9...Totati:375fe6e.html" title="Last updated on May 9, 2020, 6:50 PM UTC (375fe6e)">Diff</a>