### PR TITLE
update implementation status for write with/without response

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -39,8 +39,8 @@ getCharacteristic*()      | ✓         | ✓       | ✓   | ✓     | ✓     
 Characteristic Properties | ✓         | ✓       | ✓   | ✓     | 70       |
 Read Characteristic       | ✓         | ✓       | ✓   | ✓     | ✓       |
 Write Characteristic      | ✓         | ✓       | ✓   | ✓     | ✓       |
-└ With Response           |           |         | 👷  |       |         |
-└ Without Response        |           |         | 👷  |       |         |
+└ With Response           | 85        | 85      | 85  | 85    | 85      |
+└ Without Response        | 85        | 85      | 85  | 85    | 85      |
 Start/Stop Notifications  | ✓         | ✓       | ✓   | ✓     | 70      |
 Descriptors               | ✓         | ✓       | ✓   | ✓     | 70      |
 Event bubbling            |           |         |     |       |         |


### PR DESCRIPTION
Support for remote GATT write characteristic with and without response has been added in Chromium 85.