### PR TITLE
Update scanning.bs : filter.services can be null

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -727,7 +727,8 @@ settings object=] is no longer [=fully active=], it must run these steps:
           and <code>|filter|.namePrefix</code> is a prefix of it.
         </li>
         <li>
-          For each |uuid| in <code>|filter|.services</code>,
+          If <code>|filter|.services</code> is non-<code>null</code>,
+          for each |uuid| in <code>|filter|.services</code>,
           some <a>Service UUID</a> in |event| is equal to |uuid|.
         </li>
         <li>


### PR DESCRIPTION
In https://webbluetoothcg.github.io/web-bluetooth/scanning.html#bluetoothlescanfilter-match
As `filter.services` can be null as per the `BluetoothLEScanFilter` definition, we should precise it like in the previous steps.

[Bikeshed preview](https://api.csswg.org/bikeshed/?url=https://raw.githubusercontent.com/WebBluetoothCG/web-bluetooth/e96df2f98be9a86c2e2d5578698c7de4e5f58cab/scanning.bs#bluetoothlescanfilter-match)