### PR TITLE
Fix links to PermissionName/"bluetooth" after w3c/permissions#229.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -138,6 +138,10 @@ spec: html
 spec: webidl
     type: dfn
         text: resolve
+spec: permissions-1
+    type: enum-value
+        text: "bluetooth"
+        text: "denied"
 </pre>
 
 <style>
@@ -1298,7 +1302,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
 
     <div class="note">
       Note: |state| will be {{"denied"}} in <a>non-secure contexts</a> because
-      {{"bluetooth"}} doesn't set the <a>allowed in non-secure contexts</a>
+      {{PermissionName/"bluetooth"}} doesn't set the <a>allowed in non-secure contexts</a>
       flag.
     </div>
 1. If |state| is {{"denied"}}, return `[]` and abort these steps.
@@ -1329,7 +1333,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
     <div class="note">
       Note: Choosing a |device| probably indicates that the user
       intends that device to appear in the
-      {{BluetoothPermissionStorage/allowedDevices}} list of {{"bluetooth"}}'s
+      {{BluetoothPermissionStorage/allowedDevices}} list of {{PermissionName/"bluetooth"}}'s
       <a>extra permission data</a> for at least the <a>current settings
       object</a>, for its {{AllowedBluetoothDevice/mayUseGATT}} field to be
       `true`, for all the services in the union of
@@ -1598,7 +1602,7 @@ devices after a reload.
 </pre>
 </div>
 
-The <dfn enum-value for="PermissionName">"bluetooth"</dfn> <a>powerful
+The {{PermissionName/"bluetooth"}} <a>powerful
 feature</a>'s permission-related algorithms and types are defined as follows:
 
 <dl>
@@ -1653,7 +1657,7 @@ feature</a>'s permission-related algorithms and types are defined as follows:
       {{BluetoothDevice}} instance seen at one time represents the same device
       as another {{BluetoothDevice}} instance seen at another time, possibly in
       a different <a>realm</a>. UAs should consider whether their user intends
-      that tracking to happen or not-happen when returning {{"bluetooth"}}'s
+      that tracking to happen or not-happen when returning {{PermissionName/"bluetooth"}}'s
       <a>extra permission data</a>.
 
       For example, users generally don't intend two different origins to know
@@ -1687,7 +1691,7 @@ feature</a>'s permission-related algorithms and types are defined as follows:
         <code>|status|.devices</code> to an empty {{FrozenArray}} and abort
         these steps.
     1. Let <var>matchingDevices</var> be a new {{Array}}.
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{"bluetooth"}}'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each |allowedDevice| in <code>|storage|.allowedDevices</code>, run the
         following sub-steps:
@@ -1722,7 +1726,7 @@ feature</a>'s permission-related algorithms and types are defined as follows:
     To <dfn>revoke Bluetooth access</dfn> to devices the user no longer intends to expose,
     the UA MUST run the following steps:
 
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{"bluetooth"}}'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each {{BluetoothDevice}} instance |deviceObj| in the <a>current
         realm</a>, run the following sub-steps:
@@ -2026,7 +2030,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 <a>Bluetooth device</a> <var>device</var> inside a {{Bluetooth}} instance
 <var>context</var>, the UA MUST run the following steps:
 
-1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{"bluetooth"}}'s
+1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
     <a>extra permission data</a> for the <a>current settings object</a>.
 1. Find the |allowedDevice| in <code>|storage|.{{allowedDevices}}</code> with
     <code><var>allowedDevice</var>.{{[[device]]}}</code> the <a>same device</a>
@@ -2062,7 +2066,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 Getting the <code><dfn attribute for="BluetoothDevice">gatt</dfn></code>
 attribute MUST perform the following steps:
 
-1. If {{"bluetooth"}}'s <a>extra permission data</a> for `this`'s <a>relevant
+1. If {{PermissionName/"bluetooth"}}'s <a>extra permission data</a> for `this`'s <a>relevant
     settings object</a> has an {{AllowedBluetoothDevice}} |allowedDevice| in its
     {{BluetoothPermissionStorage/allowedDevices}} list with
     <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code> the
@@ -3756,7 +3760,7 @@ interface <a>participate in a tree</a>.
 
 * The <a>children</a> of {{Navigator/bluetooth|navigator.bluetooth}}</code></a>
     are the {{BluetoothDevice}} objects representing devices in the
-    {{BluetoothPermissionStorage/allowedDevices}} list in {{"bluetooth"}}'s
+    {{BluetoothPermissionStorage/allowedDevices}} list in {{PermissionName/"bluetooth"}}'s
     <a>extra permission data</a> for
     {{Navigator/bluetooth|navigator.bluetooth}}'s <a>relevant settings
     object</a>, in an unspecified order.

--- a/scanning.bs
+++ b/scanning.bs
@@ -58,6 +58,10 @@ spec:web-bluetooth
     type: dfn
         text: read only arraybuffer
     type:enum-value; for:PermissionName; text:"bluetooth"
+spec: permissions-1
+    type: enum-value
+        text: "denied"
+        text: "granted"
 </pre>
 
 <style>
@@ -377,7 +381,7 @@ spec:web-bluetooth
 
         readonly attribute boolean active;
 
-        void stop();
+        undefined stop();
       };
     </pre>
 

--- a/tests.bs
+++ b/tests.bs
@@ -99,13 +99,13 @@ code may access them.
 <h2 id="test-runner">testRunner</h2>
 
 <pre class="idl">
-  callback BluetoothManualChooserEventsCallback = void(sequence&lt;DOMString> events);
+  callback BluetoothManualChooserEventsCallback = undefined(sequence&lt;DOMString> events);
 
   interface TestRunner {
-    void setBluetoothMockDataSet(DOMString dataSetName);
-    void setBluetoothManualChooser();
-    void getBluetoothManualChooserEvents(BluetoothManualChooserEventsCallback callback);
-    void sendBluetoothManualChooserEvent(DOMString event, DOMString argument);
+    undefined setBluetoothMockDataSet(DOMString dataSetName);
+    undefined setBluetoothManualChooser();
+    undefined getBluetoothManualChooserEvents(BluetoothManualChooserEventsCallback callback);
+    undefined sendBluetoothManualChooserEvent(DOMString event, DOMString argument);
   };
 </pre>
 
@@ -282,7 +282,7 @@ action corresponding to the {{event}}:
 
 <pre class="idl">
   interface EventSender {
-    void keyDown(DOMString code);
+    undefined keyDown(DOMString code);
   };
 </pre>
 


### PR DESCRIPTION
w3c/permissions#229 moved all the canonical `PermissionName` definitions into the permissions spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/web-bluetooth-1/pull/540.html" title="Last updated on Feb 22, 2021, 11:44 PM UTC (555b225)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/540/f8ce14d...jyasskin:555b225.html" title="Last updated on Feb 22, 2021, 11:44 PM UTC (555b225)">Diff</a>