### PR TITLE
Configure GitHub Actions

### DIFF
--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -1,0 +1,35 @@
+name: CI
+on:
+  pull_request: {}
+  push:
+    branches: [main]
+jobs:
+  main:
+    name: Build, Validate and Deploy
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: index.bs
+          DESTINATION: index.html
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: scanning.bs
+          DESTINATION: scanning.html
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: tests.bs
+          DESTINATION: tests.html
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages
+      - uses: w3c/spec-prod@v2
+        with:
+          SOURCE: use-cases.bs
+          DESTINATION: use-cases.html
+          TOOLCHAIN: bikeshed
+          GH_PAGES_BRANCH: gh-pages

--- a/.github/workflows/pr-push.yml
+++ b/.github/workflows/pr-push.yml
@@ -9,27 +9,35 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - uses: w3c/spec-prod@v2
+      - name: index.bs
+        uses: w3c/spec-prod@v2
         with:
           SOURCE: index.bs
           DESTINATION: index.html
           TOOLCHAIN: bikeshed
+          BUILD_FAIL_ON: warning
           GH_PAGES_BRANCH: gh-pages
-      - uses: w3c/spec-prod@v2
+      - name: scanning.bs
+        uses: w3c/spec-prod@v2
         with:
           SOURCE: scanning.bs
           DESTINATION: scanning.html
           TOOLCHAIN: bikeshed
+          BUILD_FAIL_ON: warning
           GH_PAGES_BRANCH: gh-pages
-      - uses: w3c/spec-prod@v2
+      - name: tests.bs
+        uses: w3c/spec-prod@v2
         with:
           SOURCE: tests.bs
           DESTINATION: tests.html
           TOOLCHAIN: bikeshed
+          BUILD_FAIL_ON: warning
           GH_PAGES_BRANCH: gh-pages
-      - uses: w3c/spec-prod@v2
+      - name: use-cases.bs
+        uses: w3c/spec-prod@v2
         with:
           SOURCE: use-cases.bs
           DESTINATION: use-cases.html
           TOOLCHAIN: bikeshed
+          BUILD_FAIL_ON: warning
           GH_PAGES_BRANCH: gh-pages


### PR DESCRIPTION
This change configures GitHub Actions to build the specification and associated documents using Bikeshed through [Spec Prod](https://github.com/w3c/spec-prod).