### PR TITLE
Fix Bikeshed linking error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1347,7 +1347,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
 1. The UA MAY <a>populate the Bluetooth cache</a> with all Services inside
     <var>device</var>. Ignore any errors from this step.
 1. <a>Get the <code>BluetoothDevice</code> representing</a> <var>device</var>
-    inside the <a>context object</a>, propagating any exception, and let
+    inside [=this=], propagating any exception, and let
     |deviceObj| be the result.
 1. Return <code>[|deviceObj|]</code>.
 

--- a/scanning.bs
+++ b/scanning.bs
@@ -57,7 +57,6 @@ spec: webidl
 spec:web-bluetooth
     type: dfn
         text: read only arraybuffer
-    type:enum-value; for:PermissionName; text:"bluetooth"
 spec: permissions-1
     type: enum-value
         text: "denied"


### PR DESCRIPTION
This PR fixes the Bikeshed linking errors below:

```
LINK ERROR: No 'enum-value' refs found for '"bluetooth"' with spec 'web-bluetooth'.
{{"bluetooth"}}
 ✔ Successfully generated, with 1 linking errors
 ```
```
      LINK ERROR: No 'dfn' refs found for 'context object'.
      <a data-link-type="dfn" data-lt="context object">context object</a>
       ✘  Did not generate, due to fatal errors
```


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/546.html" title="Last updated on Apr 27, 2021, 1:48 PM UTC (0008a92)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/546/d5dbc97...0008a92.html" title="Last updated on Apr 27, 2021, 1:48 PM UTC (0008a92)">Diff</a>