### PR TITLE
Throw TypeError if dataPrefix is present and empty

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1481,6 +1481,9 @@ The result of <dfn for="BluetoothDataFilterInit" export>canonicalizing</dfn> the
 {{BluetoothDataFilterInit}} |filter|, is the {{BluetoothDataFilterInit}}
 returned from the following steps:
 
+1. If <code>|filter|.{{BluetoothDataFilterInit/dataPrefix}}</code> is present and
+    <code>|filter|.{{BluetoothDataFilterInit/dataPrefix}}.length === 0</code>,
+    throw a {{TypeError}} and abort these steps.
 1. If <code>|filter|.{{BluetoothDataFilterInit/dataPrefix}}</code> is present,
     let |dataPrefix| be <a>a copy of the bytes held</a> by
     <code>|filter|.dataPrefix</code>. Otherwise, let |dataPrefix| be an empty


### PR DESCRIPTION
As discussed with @reillyeon at https://chromium-review.googlesource.com/c/chromium/src/+/2830933/comment/29d40301_fc8f11ca, we may want to throw a TypeError when `dataPrefix` is present and empty to warn developers that the code they've written probably isn't doing what they think it is.

