### PR TITLE
Remove unstable for manufacturer data filter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -585,16 +585,15 @@ device has to:
     for="BluetoothLEScanFilterInit">name</dfn> if that member is present,
 * have a name starting with <dfn dict-member
     for="BluetoothLEScanFilterInit">namePrefix</dfn> if that member is present,
-* <div class="unstable"> advertise <a>manufacturer specific data</a> matching
-    all of the values in <dfn dict-member
-    for="BluetoothLEScanFilterInit">manufacturerData</dfn> if that member is
-    present, and</div>
+* advertise <a>manufacturer specific data</a> matching all of the values in
+    <dfn dict-member for="BluetoothLEScanFilterInit">manufacturerData</dfn> if
+    that member is present, and
 * <div class="unstable"> advertise <a>service data</a> matching all of the
     values in <dfn dict-member
     for="BluetoothLEScanFilterInit">serviceData</dfn> if that member is
     present.</div>
 
-<p link-for-hint="BluetoothDataFilterInit" class="unstable">
+<p link-for-hint="BluetoothDataFilterInit">
   Both <a>Manufacturer Specific Data</a> and <a>Service Data</a> map a key to an
   array of bytes. {{BluetoothDataFilterInit}} filters these arrays. An array
   matches if it has a |prefix| such that <code>|prefix| & {{mask}}</code> is
@@ -820,7 +819,7 @@ for several values of <var>filters</var> passed to
 </table>
 </div>
 
-<div class="example unstable" id="example-filter-by-manufacturer-service-data">
+<div class="example" id="example-filter-by-manufacturer-service-data">
 Say the devices in the <a href="#example-filter-by-services">previous
 example</a> also advertise manufacturer or service data as follows:
 


### PR DESCRIPTION
This PR removes "unstable" class for manufacturer data filter.

@reillyeon PTAL


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/549.html" title="Last updated on May 17, 2021, 8:33 AM UTC (0281e8e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/549/8447b7c...0281e8e.html" title="Last updated on May 17, 2021, 8:33 AM UTC (0281e8e)">Diff</a>