### PR TITLE
Documented Chrome's on-demand pairing.

### DIFF
--- a/implementation-status.md
+++ b/implementation-status.md
@@ -58,6 +58,7 @@ TypeError for bad UUIDs   | ✓         | ✓       | ✓   | ✓     | ✓     
 Invalidate GATT attributes upon disconnect | ✓ | ✓   | ✓   | ✓     | ✓     |
 GATT Blocklist            | ✓         | ✓       | ✓   | ✓     | ✓       |
 Low-latency Blocklist Updates | ✓     | ✓       | ✓   | ✓     | ✓       |
+On-demand device pairing  |           | ✓       | ✓   |        |         |
 
 ## [Scanning API](https://webbluetoothcg.github.io/web-bluetooth/scanning.html)
 


### PR DESCRIPTION
Secure characteristics may only be accessed on paired devices.
Note those platforms which currently pair on-demand when accessing
a secure characteristic.