### PR TITLE
Define "bluetooth" as a powerful feature without referencing PermissionEnum

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -46,7 +46,7 @@ Markup Shorthands: css no, markdown yes
 
 <pre class="anchors">
 spec: assigned-numbers
-    type: enum; urlPrefix: https://github.com/WebBluetoothCG/registries/        
+    type: enum; urlPrefix: https://github.com/WebBluetoothCG/registries/
         urlPrefix: blob/master/gatt_assigned_characteristics.txt
             text: body_sensor_location; url: #:~:text=body_sensor_location
             text: gap.appearance; url: #:~:text=gap.appearance
@@ -1615,8 +1615,9 @@ devices after a reload.
 </pre>
 </div>
 
-The {{PermissionName/"bluetooth"}} <a>powerful
-feature</a>'s permission-related algorithms and types are defined as follows:
+The Web Bluetooth API is a [=powerful feature=] that is identified by the
+[=powerful feature/name=] "bluetooth". Its permission-related algorithms and
+types are defined as follows:
 
 <dl>
   <dt><a>permission descriptor type</a></dt>

--- a/index.bs
+++ b/index.bs
@@ -2101,9 +2101,9 @@ run the following steps:
 
 1. If <code>|options|.{{AbortSignal|signal}}</code> is present, then perform
     the following sub-steps:
-    1. If <code>|options|.{{AbortSignal|signal}}</code>'s [=AbortSignal/aborted
-        flag=] is set, then [=abort watchAdvertisements=] with `this` and
-        abort these steps.
+    1. If <code>|options|.{{AbortSignal|signal}}</code> is
+        [=AbortSignal/aborted], then [=abort watchAdvertisements=] with `this`
+        and abort these steps.
     1. [=AbortSignal/add|Add the following abort steps=] to <code>
         |options|.{{AbortSignal|signal}}</code>:
         1. [=Abort watchAdvertisements=] with `this`.

--- a/scanning.bs
+++ b/scanning.bs
@@ -203,7 +203,7 @@ spec: permissions-1
 
     partial interface Bluetooth {
       [SecureContext]
-      Promise&lt;BluetoothLEScan> requestLEScan(optional BluetoothLEScanOptions options);
+      Promise&lt;BluetoothLEScan> requestLEScan(optional BluetoothLEScanOptions options = {});
     };
   </pre>
   <div class="note" heading="{{Bluetooth/requestLEScan()}} summary">
@@ -351,7 +351,7 @@ spec: permissions-1
     <pre class="idl">
       [Exposed=Window, SecureContext]
       interface BluetoothDataFilter {
-        constructor(optional BluetoothDataFilterInit init);
+        constructor(optional BluetoothDataFilterInit init = {});
         readonly attribute ArrayBuffer dataPrefix;
         readonly attribute ArrayBuffer mask;
       };
@@ -370,7 +370,7 @@ spec: permissions-1
 
       [Exposed=Window, SecureContext]
       interface BluetoothLEScanFilter {
-        constructor(optional BluetoothLEScanFilterInit init);
+        constructor(optional BluetoothLEScanFilterInit init = {});
         readonly attribute DOMString? name;
         readonly attribute DOMString? namePrefix;
         readonly attribute FrozenArray&lt;UUID> services;

--- a/scanning.bs
+++ b/scanning.bs
@@ -349,22 +349,26 @@ spec: permissions-1
     <h3 id="scan-control">Controlling a BLE scan</h3>
 
     <pre class="idl">
+      [Exposed=Window, SecureContext]
       interface BluetoothDataFilter {
         constructor(optional BluetoothDataFilterInit init);
         readonly attribute ArrayBuffer dataPrefix;
         readonly attribute ArrayBuffer mask;
       };
 
+      [Exposed=Window, SecureContext]
       interface BluetoothManufacturerDataFilter {
         constructor(optional object init);
         readonly maplike&lt;unsigned short, BluetoothDataFilter>;
       };
 
+      [Exposed=Window, SecureContext]
       interface BluetoothServiceDataFilter {
         constructor(optional object init);
         readonly maplike&lt;UUID, BluetoothDataFilter>;
       };
 
+      [Exposed=Window, SecureContext]
       interface BluetoothLEScanFilter {
         constructor(optional BluetoothLEScanFilterInit init);
         readonly attribute DOMString? name;
@@ -374,6 +378,7 @@ spec: permissions-1
         readonly attribute BluetoothServiceDataFilter serviceData;
       };
 
+      [Exposed=Window, SecureContext]
       interface BluetoothLEScan {
         readonly attribute FrozenArray&lt;BluetoothLEScanFilter> filters;
         readonly attribute boolean keepRepeatedDevices;
@@ -574,6 +579,7 @@ settings object=] is no longer [=fully active=], it must run these steps:
       <dt><a>permission result type</a></dt>
       <dd>
         <pre class="idl">
+          [Exposed=Window, SecureContext]
           interface BluetoothLEScanPermissionResult : PermissionStatus {
             attribute FrozenArray&lt;BluetoothLEScan> scans;
           };

--- a/tests.bs
+++ b/tests.bs
@@ -101,6 +101,7 @@ code may access them.
 <pre class="idl">
   callback BluetoothManualChooserEventsCallback = undefined(sequence&lt;DOMString> events);
 
+  [Exposed=Window, SecureContext]
   interface TestRunner {
     undefined setBluetoothMockDataSet(DOMString dataSetName);
     undefined setBluetoothManualChooser();
@@ -281,6 +282,7 @@ action corresponding to the {{event}}:
 <h2 id="event-sender">eventSender</h2>
 
 <pre class="idl">
+  [Exposed=Window, SecureContext]
   interface EventSender {
     undefined keyDown(DOMString code);
   };


### PR DESCRIPTION
As part of https://github.com/w3c/permissions/issues/263, we're making sure powerful features are properly defined in their specs. (Web Bluetooth does a great job, btw).

[PermissionName enum may go away](https://github.com/w3c/permissions/issues/314) from the permissions spec (maybe just moved into a different registry), so this PR defines "bluetooth" as a powerful feature here to be safe.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/miketaylr/web-bluetooth/pull/565.html" title="Last updated on Nov 12, 2021, 11:20 PM UTC (03d8f1b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/565/97981b7...miketaylr:03d8f1b.html" title="Last updated on Nov 12, 2021, 11:20 PM UTC (03d8f1b)">Diff</a>