### PR TITLE
Editorial: unlink "allowed in non-secure contexts flag"

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1321,8 +1321,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
 
     <div class="note">
       Note: |state| will be {{"denied"}} in <a>non-secure contexts</a> because
-      {{PermissionName/"bluetooth"}} doesn't set the <a>allowed in non-secure contexts</a>
-      flag.
+      powerful features can't be used in <a>non-secure contexts</a>.
     </div>
 1. If |state| is {{"denied"}}, return `[]` and abort these steps.
 1. If the UA can prove that no devices could possibly be found in the next step,


### PR DESCRIPTION
The "allowed in non-secure contexts flag" export was removed from Permissions.
https://github.com/w3c/permissions/pull/327