### PR TITLE
Add BluetoothDevice.forget()

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -119,7 +119,6 @@ spec: webidl
         text: resolve
 spec: permissions-1
     type: enum-value
-        text: "bluetooth"
         text: "denied"
 </pre>
 
@@ -1351,7 +1350,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
     <div class="note">
       Note: Choosing a |device| probably indicates that the user
       intends that device to appear in the
-      {{BluetoothPermissionStorage/allowedDevices}} list of {{PermissionName/"bluetooth"}}'s
+      {{BluetoothPermissionStorage/allowedDevices}} list of "<code>bluetooth</code>"'s
       <a>extra permission data</a> for at least the <a>current settings
       object</a>, for its {{AllowedBluetoothDevice/mayUseGATT}} field to be
       `true`, for all the services in the union of
@@ -1685,7 +1684,7 @@ types are defined as follows:
       {{BluetoothDevice}} instance seen at one time represents the same device
       as another {{BluetoothDevice}} instance seen at another time, possibly in
       a different <a>realm</a>. UAs should consider whether their user intends
-      that tracking to happen or not-happen when returning {{PermissionName/"bluetooth"}}'s
+      that tracking to happen or not-happen when returning "<code>bluetooth</code>"'s
       <a>extra permission data</a>.
 
       For example, users generally don't intend two different origins to know
@@ -1719,7 +1718,7 @@ types are defined as follows:
         <code>|status|.devices</code> to an empty {{FrozenArray}} and abort
         these steps.
     1. Let <var>matchingDevices</var> be a new {{Array}}.
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each |allowedDevice| in <code>|storage|.allowedDevices</code>, run the
         following sub-steps:
@@ -1754,7 +1753,7 @@ types are defined as follows:
     To <dfn>revoke Bluetooth access</dfn> to devices the user no longer intends to expose,
     the UA MUST run the following steps:
 
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each {{BluetoothDevice}} instance |deviceObj| in the <a>current
         realm</a>, run the following sub-steps:
@@ -2062,7 +2061,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 <a>Bluetooth device</a> <var>device</var> inside a {{Bluetooth}} instance
 <var>context</var>, the UA MUST run the following steps:
 
-1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
+1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
     <a>extra permission data</a> for the <a>current settings object</a>.
 1. Find the |allowedDevice| in <code>|storage|.{{allowedDevices}}</code> with
     <code><var>allowedDevice</var>.{{[[device]]}}</code> the <a>same device</a>
@@ -2098,7 +2097,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 Getting the <code><dfn attribute for="BluetoothDevice">gatt</dfn></code>
 attribute MUST perform the following steps:
 
-1. If {{PermissionName/"bluetooth"}}'s <a>extra permission data</a> for `this`'s <a>relevant
+1. If "<code>bluetooth</code>"'s <a>extra permission data</a> for `this`'s <a>relevant
     settings object</a> has an {{AllowedBluetoothDevice}} |allowedDevice| in its
     {{BluetoothPermissionStorage/allowedDevices}} list with
     <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code> the
@@ -3804,7 +3803,7 @@ interface <a>participate in a tree</a>.
 
 * The <a>children</a> of {{Navigator/bluetooth|navigator.bluetooth}}</code></a>
     are the {{BluetoothDevice}} objects representing devices in the
-    {{BluetoothPermissionStorage/allowedDevices}} list in {{PermissionName/"bluetooth"}}'s
+    {{BluetoothPermissionStorage/allowedDevices}} list in "<code>bluetooth</code>"'s
     <a>extra permission data</a> for
     {{Navigator/bluetooth|navigator.bluetooth}}'s <a>relevant settings
     object</a>, in an unspecified order.

--- a/index.bs
+++ b/index.bs
@@ -2232,11 +2232,12 @@ aborted.
 
 <div algorithm="handle visibility change">
 When the user agent determines that the [=document visibility state|visibility
-state=] of the [=responsible document=] of the [=current settings object=]
-changes, it must run these steps:
+state=] of the <a>associated <code>Document</code></a> of the
+[=current settings object=]'s [=relevant global object=] changes, it must run
+these steps:
 
-1. Let <code>|document|</code> be the [=responsible document=] of the [=current
-    settings object=].
+1. Let <code>|document|</code> be the <a>associated <code>Document</code></a> of
+    the [=current settings object=]'s [=relevant global object=].
 1. If <code>|document|</code>'s [=document visibility state|visibility state=]
     is not <code>"visible"</code>, then [=abort all active watchAdvertisements=]
     operations.
@@ -2252,8 +2253,9 @@ active=] [=document=]. When [=fully active|full activity=] is lost, scanning
 operations for that [=document=] need to be aborted.
 
 <div algorithm="handle full activity loss">
-When the user agent determines that a [=responsible document=] of the [=current
-settings object=] is no longer [=fully active=], it must run these steps:
+When the user agent determines that a <a>associated <code>Document</code></a> of
+the [=current settings object=]'s [=relevant global object=] is no longer
+[=fully active=], it must run these steps:
 
 1. Run [=abort all active watchAdvertisements=] operations.
 

--- a/index.bs
+++ b/index.bs
@@ -1589,6 +1589,21 @@ UA MUST run the following steps:
 </div>
 
 <div class="unstable">
+
+To <dfn data-lt="remove device from storage">remove an allowed <a>Bluetooth
+device</a></dfn> |device|, given a {{BluetoothPermissionStorage}} |storage|,
+the UA MUST run the following steps:
+
+1. Search for an element |allowedDevice| in
+    <code>|storage|.{{BluetoothPermissionStorage/allowedDevices}}</code> where
+    |device| is equal to <code>|allowedDevice|@{{[[device]]}}</code>. If no such
+    element exists, abort these steps.
+1. Remove |allowedDevice| from
+    <code>|storage|.{{BluetoothPermissionStorage/allowedDevices}}</code>.
+
+</div>
+
+<div class="unstable">
 ## Permission API Integration ## {#permission-api-integration}
 
 The [[permissions]] API provides a uniform way for websites to query which
@@ -1940,6 +1955,7 @@ or {{Bluetooth}} instance).
     readonly attribute DOMString? name;
     readonly attribute BluetoothRemoteGATTServer? gatt;
 
+    Promise<undefined> forget();
     Promise<undefined> watchAdvertisements(
         optional WatchAdvertisementsOptions options = {});
     readonly attribute boolean watchingAdvertisements;
@@ -1964,6 +1980,9 @@ fact to script</a>.
 
 {{BluetoothDevice/gatt}} provides a way to interact with this device's GATT
 server if the site has permission to do so.
+
+{{BluetoothDevice/forget()}} enables the page to revoke access to the device
+that the user has granted access to.
 
 <dfn>watchingAdvertisements</dfn> is true if the UA is currently scanning for
 advertisements from this device and firing events for them.
@@ -2087,6 +2106,18 @@ attribute MUST perform the following steps:
     <code>|allowedDevice|.{{AllowedBluetoothDevice/mayUseGATT}}</code> equal to
     `true`, return <code>this.{{[[gatt]]}}</code>.
 1. Otherwise, return `null`.
+
+</div>
+
+<div algorithm="forget invocation">
+The <code><dfn method for="BluetoothDevice">forget()</dfn></code> method, when
+invoked, MUST return <a>a new promise</a> |promise| and run the following steps:
+
+1. Let |device| be the target {{BluetoothDevice}} object.
+1. Let |storage| be the {{BluetoothPermissionStorage}} object in the current
+    script execution environment.
+1. <a>Remove |device| from storage</a> with |storage|.
+1. <a>Resolve</a> |promise|.
 
 </div>
 

--- a/scanning.bs
+++ b/scanning.bs
@@ -57,9 +57,10 @@ spec: webidl
 spec:web-bluetooth
     type: dfn
         text: read only arraybuffer
+    type: permission
+        text: "bluetooth"
 spec: permissions-1
     type: enum-value
-        text: "bluetooth"
         text: "denied"
         text: "granted"
 </pre>
@@ -676,7 +677,7 @@ the [=current settings object=]'s [=relevant global object=] is no longer
               Note: the user's <a href="#scanning-permission">permission to scan</a>
               likely indicates that
               they intend newly-discovered devices to appear in
-              {{"bluetooth"}}'s <a>extra permission data</a>,
+              <a permission>"bluetooth"</a>'s <a>extra permission data</a>,
               but possibly with {{AllowedBluetoothDevice/mayUseGATT}} set to `false`.
             </li>
             <li>

--- a/scanning.bs
+++ b/scanning.bs
@@ -544,8 +544,9 @@ active=] [=document=]. When [=fully active|full activity=] is lost, scanning
 operations for that [=document=] need to be aborted.
 
 <div algorithm="handle full activity loss">
-When the user agent determines that a [=responsible document=] of the [=current
-settings object=] is no longer [=fully active=], it must run these steps:
+When the user agent determines that a <a>associated <code>Document</code></a> of
+the [=current settings object=]'s [=relevant global object=] is no longer
+[=fully active=], it must run these steps:
 
 1. [=map/For each=] |activeScan| in <code>
     navigator.bluetooth.{{[[activeScans]]}}</code>, perform the following

--- a/tests.bs
+++ b/tests.bs
@@ -81,7 +81,11 @@ href="https://code.google.com/p/chromium/codesearch/#chromium/src/third_party/We
 repository</a>.
 
 
-<h2 id="security-and-privacy">Security and privacy considerations</h2>
+<h2 id="security-and-privacy">Security considerations</h2>
+
+Issue(575): See <a href="#privacy"></a> section.
+
+<h2 id="privacy">Privacy considerations</h2>
 
 These functions MUST NOT be exposed to web content. Only trusted testing
 code may access them.

--- a/use-cases.bs
+++ b/use-cases.bs
@@ -175,7 +175,11 @@ Markup Shorthands: css no, markdown yes
 </section>
 
 <section>
-  <h2 id="security_privacy">Security and Privacy Considerations</h2>
+  <h2 id="security_privacy">Security considerations</h2>
+
+  Issue(575): See <a href="#privacy"></a> section.
+
+  <h2 id="privacy">Privacy considerations</h2>
 
   <section>
     <h3 id="risks">Risks</h3>


### PR DESCRIPTION
Similarly to [HIDDevice.forget()](https://chromestatus.com/feature/5723581527883776) and [USBDevice forget()](https://chromestatus.com/feature/5640127995969536), this PR adds BluetoothDevice.forget() so that web developers can revoke permission access to a paired BluetoothDevice.

```js
// Request a Bluetooth device.
const device = await navigator.bluetooth.requestDevice({ acceptAllDevices: true });

// Then later... revoke permission to the Bluetooth device.
await device.forget();
```

@reillyeon Please have a look


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/574.html" title="Last updated on Apr 11, 2022, 8:34 AM UTC (bea3a26)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/574/cecb7f1...bea3a26.html" title="Last updated on Apr 11, 2022, 8:34 AM UTC (bea3a26)">Diff</a>