### PR TITLE
Use string literal for permission name

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1350,7 +1350,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
     <div class="note">
       Note: Choosing a |device| probably indicates that the user
       intends that device to appear in the
-      {{BluetoothPermissionStorage/allowedDevices}} list of "<code>bluetooth</code>"'s
+      {{BluetoothPermissionStorage/allowedDevices}} list of <a permission>"bluetooth"</a>'s
       <a>extra permission data</a> for at least the <a>current settings
       object</a>, for its {{AllowedBluetoothDevice/mayUseGATT}} field to be
       `true`, for all the services in the union of
@@ -1614,8 +1614,8 @@ devices after a reload.
 </div>
 
 The Web Bluetooth API is a [=powerful feature=] that is identified by the
-[=powerful feature/name=] "bluetooth". Its permission-related algorithms and
-types are defined as follows:
+[=powerful feature/name=] <dfn permission export>"bluetooth"</dfn>. Its
+permission-related algorithms and types are defined as follows:
 
 <dl>
   <dt><a>permission descriptor type</a></dt>
@@ -1669,7 +1669,7 @@ types are defined as follows:
       {{BluetoothDevice}} instance seen at one time represents the same device
       as another {{BluetoothDevice}} instance seen at another time, possibly in
       a different <a>realm</a>. UAs should consider whether their user intends
-      that tracking to happen or not-happen when returning "<code>bluetooth</code>"'s
+      that tracking to happen or not-happen when returning <a permission>"bluetooth"</a>'s
       <a>extra permission data</a>.
 
       For example, users generally don't intend two different origins to know
@@ -1703,7 +1703,7 @@ types are defined as follows:
         <code>|status|.devices</code> to an empty {{FrozenArray}} and abort
         these steps.
     1. Let <var>matchingDevices</var> be a new {{Array}}.
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be <a permission>"bluetooth"</a>'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each |allowedDevice| in <code>|storage|.allowedDevices</code>, run the
         following sub-steps:
@@ -1738,7 +1738,7 @@ types are defined as follows:
     To <dfn>revoke Bluetooth access</dfn> to devices the user no longer intends to expose,
     the UA MUST run the following steps:
 
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be <a permission>"bluetooth"</a>'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each {{BluetoothDevice}} instance |deviceObj| in the <a>current
         realm</a>, run the following sub-steps:
@@ -2042,7 +2042,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 <a>Bluetooth device</a> <var>device</var> inside a {{Bluetooth}} instance
 <var>context</var>, the UA MUST run the following steps:
 
-1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
+1. Let |storage|, a {{BluetoothPermissionStorage}}, be <a permission>"bluetooth"</a>'s
     <a>extra permission data</a> for the <a>current settings object</a>.
 1. Find the |allowedDevice| in <code>|storage|.{{allowedDevices}}</code> with
     <code><var>allowedDevice</var>.{{[[device]]}}</code> the <a>same device</a>
@@ -2078,7 +2078,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 Getting the <code><dfn attribute for="BluetoothDevice">gatt</dfn></code>
 attribute MUST perform the following steps:
 
-1. If "<code>bluetooth</code>"'s <a>extra permission data</a> for `this`'s <a>relevant
+1. If <a permission>"bluetooth"</a>'s <a>extra permission data</a> for `this`'s <a>relevant
     settings object</a> has an {{AllowedBluetoothDevice}} |allowedDevice| in its
     {{BluetoothPermissionStorage/allowedDevices}} list with
     <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code> the
@@ -3772,8 +3772,8 @@ interface <a>participate in a tree</a>.
 
 * The <a>children</a> of {{Navigator/bluetooth|navigator.bluetooth}}</code></a>
     are the {{BluetoothDevice}} objects representing devices in the
-    {{BluetoothPermissionStorage/allowedDevices}} list in "<code>bluetooth</code>"'s
-    <a>extra permission data</a> for
+    {{BluetoothPermissionStorage/allowedDevices}} list in <a
+    permission>"bluetooth"</a>'s <a>extra permission data</a> for
     {{Navigator/bluetooth|navigator.bluetooth}}'s <a>relevant settings
     object</a>, in an unspecified order.
 * The <a>children</a> of a {{BluetoothDevice}} are the

--- a/index.bs
+++ b/index.bs
@@ -119,7 +119,6 @@ spec: webidl
         text: resolve
 spec: permissions-1
     type: enum-value
-        text: "bluetooth"
         text: "denied"
 </pre>
 
@@ -1351,7 +1350,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
     <div class="note">
       Note: Choosing a |device| probably indicates that the user
       intends that device to appear in the
-      {{BluetoothPermissionStorage/allowedDevices}} list of {{PermissionName/"bluetooth"}}'s
+      {{BluetoothPermissionStorage/allowedDevices}} list of "<code>bluetooth</code>"'s
       <a>extra permission data</a> for at least the <a>current settings
       object</a>, for its {{AllowedBluetoothDevice/mayUseGATT}} field to be
       `true`, for all the services in the union of
@@ -1670,7 +1669,7 @@ types are defined as follows:
       {{BluetoothDevice}} instance seen at one time represents the same device
       as another {{BluetoothDevice}} instance seen at another time, possibly in
       a different <a>realm</a>. UAs should consider whether their user intends
-      that tracking to happen or not-happen when returning {{PermissionName/"bluetooth"}}'s
+      that tracking to happen or not-happen when returning "<code>bluetooth</code>"'s
       <a>extra permission data</a>.
 
       For example, users generally don't intend two different origins to know
@@ -1704,7 +1703,7 @@ types are defined as follows:
         <code>|status|.devices</code> to an empty {{FrozenArray}} and abort
         these steps.
     1. Let <var>matchingDevices</var> be a new {{Array}}.
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each |allowedDevice| in <code>|storage|.allowedDevices</code>, run the
         following sub-steps:
@@ -1739,7 +1738,7 @@ types are defined as follows:
     To <dfn>revoke Bluetooth access</dfn> to devices the user no longer intends to expose,
     the UA MUST run the following steps:
 
-    1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
+    1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
         <a>extra permission data</a> for the <a>current settings object</a>.
     1. For each {{BluetoothDevice}} instance |deviceObj| in the <a>current
         realm</a>, run the following sub-steps:
@@ -2043,7 +2042,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 <a>Bluetooth device</a> <var>device</var> inside a {{Bluetooth}} instance
 <var>context</var>, the UA MUST run the following steps:
 
-1. Let |storage|, a {{BluetoothPermissionStorage}}, be {{PermissionName/"bluetooth"}}'s
+1. Let |storage|, a {{BluetoothPermissionStorage}}, be "<code>bluetooth</code>"'s
     <a>extra permission data</a> for the <a>current settings object</a>.
 1. Find the |allowedDevice| in <code>|storage|.{{allowedDevices}}</code> with
     <code><var>allowedDevice</var>.{{[[device]]}}</code> the <a>same device</a>
@@ -2079,7 +2078,7 @@ To <dfn export>get the <code>BluetoothDevice</code> representing</dfn> a
 Getting the <code><dfn attribute for="BluetoothDevice">gatt</dfn></code>
 attribute MUST perform the following steps:
 
-1. If {{PermissionName/"bluetooth"}}'s <a>extra permission data</a> for `this`'s <a>relevant
+1. If "<code>bluetooth</code>"'s <a>extra permission data</a> for `this`'s <a>relevant
     settings object</a> has an {{AllowedBluetoothDevice}} |allowedDevice| in its
     {{BluetoothPermissionStorage/allowedDevices}} list with
     <code>|allowedDevice|.{{AllowedBluetoothDevice/[[device]]}}</code> the
@@ -3773,7 +3772,7 @@ interface <a>participate in a tree</a>.
 
 * The <a>children</a> of {{Navigator/bluetooth|navigator.bluetooth}}</code></a>
     are the {{BluetoothDevice}} objects representing devices in the
-    {{BluetoothPermissionStorage/allowedDevices}} list in {{PermissionName/"bluetooth"}}'s
+    {{BluetoothPermissionStorage/allowedDevices}} list in "<code>bluetooth</code>"'s
     <a>extra permission data</a> for
     {{Navigator/bluetooth|navigator.bluetooth}}'s <a>relevant settings
     object</a>, in an unspecified order.


### PR DESCRIPTION
> It looks like you'll need to create an update to how this specification references the Permissions API before this PR can be merged.

I've fixed this by following https://github.com/whatwg/storage/pull/136 example.

_Originally posted by @beaufortfrancois in https://github.com/WebBluetoothCG/web-bluetooth/issues/574#issuecomment-1060653327_

PTAL @reillyeon


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/577.html" title="Last updated on Mar 8, 2022, 12:00 PM UTC (046ca9b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/577/b5f7617...046ca9b.html" title="Last updated on Mar 8, 2022, 12:00 PM UTC (046ca9b)">Diff</a>