### PR TITLE
Permissions Policy integration

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1218,6 +1218,10 @@ To <code><dfn method for="Bluetooth">getDevices()</dfn></code> method, when
 invoked and given a {{BluetoothPermissionStorage}} |storage|, MUST return
 [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
+1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not
+    [=allowed to use=] the [=policy-controlled feature=] named 
+    "[=policy-controlled feature/bluetooth=]", <a>reject</a> |promise| with a
+    {{SecurityError}} and abort these steps.
 1. Let |devices| be a new empty {{Array}}.
 1. For each |allowedDevice| in
     <code>|storage|.{{BluetoothPermissionStorage/allowedDevices}}</code>, add
@@ -1287,6 +1291,10 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
   devices, but for now it only ever returns a single one.
 </div>
 
+1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not
+    [=allowed to use=] the [=policy-controlled feature=] named 
+    "[=policy-controlled feature/bluetooth=]", throw a {{SecurityError}} and
+    abort these steps.
 1. <p id="requestDevice-user-gesture">Check that the algorithm is triggered
     while its [=relevant global object=] has a
     <a href="https://html.spec.whatwg.org/#tracking-user-activation"> transient
@@ -1817,6 +1825,10 @@ The <code><dfn method for="Bluetooth">getAvailability()</dfn></code> method,
 when invoked, MUST return <a>a new promise</a> |promise| and run the following
 steps <a>in parallel</a>:
 
+1. If [=this=]'s [=relevant global object=]'s [=associated Document=] is not
+    [=allowed to use=] the [=policy-controlled feature=] named 
+    "[=policy-controlled feature/bluetooth=]", <a>queue a task</a> to
+    <a>resolve</a> |promise| with `false`, and abort these steps.
 1. <p id="override-availability">If the user has configured the UA to return a
     particular answer from this function for the current origin, <a>queue a
     task</a> to <a>resolve</a> |promise| with the configured answer, and abort
@@ -4579,7 +4591,10 @@ blocklist</a>.
 
 ## Permissions Policy ## {#permissions-policy}
 
-This specification defines a <a>policy-controlled feature</a>, identified by the token <code>"bluetooth"</code>, that controls whether the methods exposed by the {{Navigator/bluetooth}} attribute on the {{Navigator}} object may be used.
+This specification defines a <a>policy-controlled feature</a>, identified by
+the token "<dfn data-dfn-for="policy-controlled feature"><code>bluetooth</code></dfn>",
+that controls whether the methods exposed by the {{Navigator/bluetooth}}
+attribute on the {{Navigator}} object may be used.
 
 The <a>default allowlist</a> for this feature is <code>["self"]</code>.
 

--- a/index.bs
+++ b/index.bs
@@ -417,6 +417,10 @@ several approaches to make such attacks more difficult:
     injection attacks</a>. Unfortunately, this only works over encrypted links,
     which not all BLE devices are required to support.
 
+* The integration with [[#permissions-policy]] provides protection against unwanted
+    access to Bluetooth capabilities, which requires the top-level document to
+    explicitly allow a cross-origin iframe to use the API's methods.
+
 UAs can also take further steps to protect their users:
 
 * A web service may collect lists of malicious websites and vulnerable devices.
@@ -4538,6 +4542,14 @@ blocklist</a>.
     readonly attribute Bluetooth bluetooth;
   };
 </xmp>
+
+# Integrations # {#integrations}
+
+## Permissions Policy ## {#permissions-policy}
+
+This specification defines a <a>policy-controlled feature</a>, identified by the token <code>"bluetooth"</code>, that controls whether the methods exposed by the {{Navigator/bluetooth}} attribute on the {{Navigator}} object may be used.
+
+The <a>default allowlist</a> for this feature is <code>["self"]</code>.
 
 # Terminology and Conventions # {#terminology}
 

--- a/scanning.bs
+++ b/scanning.bs
@@ -252,6 +252,12 @@ spec: permissions-1
     </p>
     <ol class="algorithm">
       <li>
+        If [=this=]'s [=relevant global object=]'s [=associated Document=] is 
+        not [=allowed to use=] the [=policy-controlled feature=] named 
+        <code>"bluetooth"</code>, <a>reject</a> |promise| with a 
+        {{SecurityError}} and abort these steps.
+      </li>
+      <li>
         If <code>|options|.acceptAllAdvertisements</code> is `true`,
         and <code>|options|.filters</code> is present,
         <a>reject</a> |promise| with a {{TypeError}} and abort these steps.


### PR DESCRIPTION
This PR specifies the integration of the Web Bluetooth API with Permissions Policy, so that developers have more control over Bluetooth availability, especially in cross-origin iframe scenarios. 

[index.bs preview](https://api.csswg.org/bikeshed/?url=https://github.com/gabrielsanbrito/web-bluetooth/raw/permissions-policy-integration/index.bs)
[scanning.bs preview](https://api.csswg.org/bikeshed/?url=https://github.com/gabrielsanbrito/web-bluetooth/raw/permissions-policy-integration/scanning.bs)

@reillyeon PTAL when convenient.
Thanks!


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/gabrielsanbrito/web-bluetooth/pull/582.html" title="Last updated on Apr 13, 2022, 8:24 PM UTC (9b3dd28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/582/f9ee525...gabrielsanbrito:9b3dd28.html" title="Last updated on Apr 13, 2022, 8:24 PM UTC (9b3dd28)">Diff</a>