### PR TITLE
Associate relevant events dfn with mixin BluetoothDeviceEventHandlers

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2511,8 +2511,8 @@ the UA MUST perform the following steps:
       <dd>Skip to the next AD structure.</dd>
     </dl>
 
-1. <a>Fire an event</a> initialized as <code>new
-    {{BluetoothAdvertisingEvent}}("{{advertisementreceived}}",
+1. <a>Fire an event</a> named "{{advertisementreceived}}" using
+    {{BluetoothAdvertisingEvent}} initialized with
     <var>event</var>)</code>, with its {{Event/isTrusted}} attribute initialized
     to `true`, at <var>deviceObj</var>.
 
@@ -3853,7 +3853,7 @@ interface <a>participate in a tree</a>.
 
 <dl>
   <dt>
-    <dfn event for="BluetoothDevice"><code>advertisementreceived</code></dfn>
+    <dfn event for="BluetoothDeviceEventHandlers"><code>advertisementreceived</code></dfn>
   </dt>
   <dd>
     Fired on a {{BluetoothDevice}} when an
@@ -3882,7 +3882,7 @@ interface <a>participate in a tree</a>.
   </dd>
 
   <dt>
-    <dfn event for="BluetoothDevice"><code>gattserverdisconnected</code></dfn>
+    <dfn event for="BluetoothDeviceEventHandlers"><code>gattserverdisconnected</code></dfn>
   </dt>
   <dd>
     Fired on a {{BluetoothDevice}} when


### PR DESCRIPTION
Also use 'fire an event' phrasing in line with DOM suggestion https://dom.spec.whatwg.org/#firing-events-example