### PR TITLE
Fix bikeshed issue with 'denied'

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -117,9 +117,6 @@ spec: html
 spec: webidl
     type: dfn
         text: resolve
-spec: permissions-1
-    type: enum-value
-        text: "denied"
 </pre>
 
 <style>
@@ -1335,10 +1332,10 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
 1. Let |state| be |descriptor|'s <a>permission state</a>.
 
     <div class="note">
-      Note: |state| will be {{"denied"}} in <a>non-secure contexts</a> because
+      Note: |state| will be "{{PermissionState/denied}}" in <a>non-secure contexts</a> because
       powerful features can't be used in <a>non-secure contexts</a>.
     </div>
-1. If |state| is {{"denied"}}, return `[]` and abort these steps.
+1. If |state| is "{{PermissionState/denied}}", return `[]` and abort these steps.
 1. If the UA can prove that no devices could possibly be found in the next step,
     for example because there is no Bluetooth adapter with which to scan, or
     because the filters can't be matched by any possible advertising packet, the
@@ -1376,7 +1373,7 @@ all devices can match, a sequence of {{BluetoothServiceUUID}}s,
       |optionalManufacturerData| to appear in its
       {{AllowedBluetoothDevice/allowedManufacturerData}} list.
     </div>
-1. If |device| is {{"denied"}}, return `[]` and abort these steps.
+1. If |device| is "{{PermissionState/denied}}", return `[]` and abort these steps.
 1. The UA MAY <a>populate the Bluetooth cache</a> with all Services inside
     <var>device</var>. Ignore any errors from this step.
 1. <a>Get the <code>BluetoothDevice</code> representing</a> <var>device</var>
@@ -1730,7 +1727,7 @@ permission-related algorithms and types are defined as follows:
         <var>status</var>.
     1. Set <code><var>status</var>.{{PermissionStatus/state}}</code> to |desc|'s
         <a>permission state</a>.
-    1. If <code>|status|.{{PermissionStatus/state}}</code> is {{"denied"}}, set
+    1. If <code>|status|.{{PermissionStatus/state}}</code> is "{{PermissionState/denied}}", set
         <code>|status|.devices</code> to an empty {{FrozenArray}} and abort
         these steps.
     1. Let <var>matchingDevices</var> be a new {{Array}}.


### PR DESCRIPTION
This PR fixes bikeshed issue below:

```
    $ bikeshed --die-on=warning spec "index.bs" "index.bs.built.html" 
      LINK ERROR: No 'enum-value' refs found for '"denied"' with spec 'permissions-1'.
      {{"denied"}}
       ✘  Did not generate, due to fatal errors
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/601.html" title="Last updated on Mar 24, 2023, 12:05 PM UTC (c9615cc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/601/696bb7a...c9615cc.html" title="Last updated on Mar 24, 2023, 12:05 PM UTC (c9615cc)">Diff</a>