### PR TITLE
Fix bikeshed issue with 'denied'

### DIFF
--- a/scanning.bs
+++ b/scanning.bs
@@ -59,10 +59,6 @@ spec:web-bluetooth
         text: read only arraybuffer
     type: permission
         text: "bluetooth"
-spec: permissions-1
-    type: enum-value
-        text: "denied"
-        text: "granted"
 </pre>
 
 <style>
@@ -295,7 +291,7 @@ spec: permissions-1
         activation</a> on its [=relevant global object=] when triggered.
       </li>
       <li>
-        If the result is {{"denied"}},
+        If the result is "{{PermissionState/denied}}",
         reject |promise| with a {{NotAllowedError}} and abort these steps.
       </li>
       <li>
@@ -606,7 +602,7 @@ the [=current settings object=]'s [=relevant global object=] is no longer
             to |descriptor|'s <a>permission state</a>.
           </li>
           <li>
-            If <code>|result|.{{PermissionStatus/state}}</code> is {{"denied"}},
+            If <code>|result|.{{PermissionStatus/state}}</code> is "{{PermissionState/denied}}",
             set <code>|result|.scans</code> to an empty {{FrozenArray}}
             and abort these steps.
           </li>
@@ -640,7 +636,7 @@ the [=current settings object=]'s [=relevant global object=] is no longer
                     keepRepeatedDevices: <var>activeScan</var>.keepRepeatedDevices
                   }
                 </pre>
-                is not {{"granted"}},
+                is not "{{PermissionState/granted}}",
                 call <code>|activeScan|.{{stop()}}</code>.
               </li>
             </ol>


### PR DESCRIPTION
This PR fixes bikeshed issue below:

```
    $ bikeshed --die-on=warning spec "scanning.bs" "scanning.bs.built.html" 
      LINK ERROR: No 'enum-value' refs found for '"denied"' with spec 'permissions-1'.
      {{"denied"}}
       ✘  Did not generate, due to fatal errors
    Command `bikeshed --die-on=warning spec "scanning.bs" "scanning.bs.built.html" ` failed with exit code: 2.
```