### PR TITLE
Fix WebDriver dfn url error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -4487,7 +4487,7 @@ Response</a></code>, the UA MUST perform the following steps:
   typedef DOMString UUID;
 </xmp>
 
-A <a>UUID</a> string represents a 128-bit [[!RFC4122]] UUID. A <dfn>valid
+A <a>UUID</a> string represents a 128-bit [[!RFC4122 obsolete]] UUID. A <dfn>valid
 UUID</dfn> is a string that matches the [[!ECMAScript]] regexp
 <code>/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/</code>.
 That is, a <a>valid UUID</a> is lower-case and does not use the 16- or 32-bit

--- a/index.bs
+++ b/index.bs
@@ -108,7 +108,7 @@ spec: PAGE-VISIBILITY; urlPrefix: https://www.w3.org/TR/page-visibility-2/#
 
 spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
-        text: error; url: dfn-errors
+        text: error; url: dfn-error
         text: local end; url: dfn-local-ends
 
 </pre>


### PR DESCRIPTION
This PR fixes #626 by correcting the WebDriver spec's  dfn url.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alvinjiooo/web-bluetooth/pull/627.html" title="Last updated on May 15, 2024, 9:34 PM UTC (9e9917c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/627/35c034e...alvinjiooo:9e9917c.html" title="Last updated on May 15, 2024, 9:34 PM UTC (9e9917c)">Diff</a>