### PR TITLE
Export definitions required by the Scanning API

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -560,8 +560,9 @@ that UAs will choose not to prompt.
   Bluetooth includes ServiceEventHandlers;
 </xmp>
 
-Methods defined in this specification typically complete asynchronously, queuing
-work on the <dfn>Bluetooth task source</dfn>.
+Methods defined in this specification typically complete asynchronously,
+queuing work on a <dfn lt="Bluetooth task source" export>Bluetooth</dfn>
+[=task source=].
 
 <div class="note" heading="{{Bluetooth}} members">
 Note: {{Bluetooth/getAvailability()}} informs the page whether Bluetooth is
@@ -4937,7 +4938,7 @@ if the following steps return `blocked`:
   };
 </xmp>
 
-Each {{Navigator}} has an <dfn>associated `Bluetooth`</dfn>, which is a
+Each {{Navigator}} has an <dfn export>associated `Bluetooth`</dfn>, which is a
 {{Bluetooth}} object. Upon creation of the {{Navigator}} object, its
 <a>associated `Bluetooth`</a> must be set to a new {{Bluetooth}} object
 created in the {{Navigator}} object's [=relevant realm=].


### PR DESCRIPTION
As an extenion to the Web Bluetooth API it needs access to the "Bluetooth task source" and "assocaited Bluetooth" definitions.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/pull/644.html" title="Last updated on Feb 13, 2025, 6:49 PM UTC (14a8404)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/644/030375d...14a8404.html" title="Last updated on Feb 13, 2025, 6:49 PM UTC (14a8404)">Diff</a>