### PR TITLE
Update bluetooth.simulateAdapter command

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -2027,6 +2027,9 @@ steps <a>in parallel</a>:
     1. If |simulatedBluetoothAdapter|'s [=adapter state=] is "absent", [=queue
         a global task=] on the [=Bluetooth task source=] given |global| to
         [=resolve=] |promise| with `false`.
+    1. If |simulatedBluetoothAdapter|'s [=LE supported state=] is `false`, [=queue
+        a global task=] on the [=Bluetooth task source=] given |global| to
+        [=resolve=] |promise| with `false`.
     1. Otherwise, [=queue a global task=] on the [=Bluetooth task source=]
         given |global| to [=resolve=] |promise| with `true`.
     1. Abort these steps.
@@ -4972,7 +4975,7 @@ Each <a>simulated Bluetooth adapter</a> has an <dfn>adapter state</dfn> that is 
   * "powered-off"
   * "absent"
 
-Each <a>simulated Bluetooth adapter</a> has a <dfn>le supported state</dfn> that is a boolean describing if the adapter supports Bluetooth Low Energy.
+Each <a>simulated Bluetooth adapter</a> has a <dfn lt="LE supported state">low-energy supported state</dfn> that is a boolean describing if the adapter supports Bluetooth Low Energy.
 
 A <dfn>simulated Bluetooth device</dfn> is a software defined [=Bluetooth device=] that behaves like a physical device, and may be attached to a <a>simulated Bluetooth adapter</a>, and may have associated properties like <a>Manufacturer Specific Data</a> and <a>Service UUIDs</a>.
 
@@ -5209,17 +5212,20 @@ The [=remote end steps=] with command parameters |params| are:
     1. If |params|[`"leSupported"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
     1. If |params|[`"state"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
     1. Let |simulatedBluetoothAdapter| be a new [=simulated Bluetooth adapter=].
-    1. Set |simulatedBluetoothAdapter|'s <a>le supported state</a> to |params|[`"leSupported"`].
+    1. Set |simulatedBluetoothAdapter|'s <a>LE supported state</a> to |params|[`"leSupported"`].
     1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
     1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to |simulatedBluetoothAdapter|.
     1. Return [=success=] with data `null`.
 1. If |params|[`"type"`] is `update`, run the following steps:
+    1. If |params|[`"leSupported"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
     1. If |params|[`"state"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
     1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
     1. If |simulatedBluetoothAdapter| is empty, return [=error=] with [=error code=] [=invalid argument=].
     1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
     1. Return [=success=] with data `null`.
 1. If |params|[`"type"`] is `remove`, run the following steps:
+    1. If |params|[`"leSupported"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
+    1. If |params|[`"state"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
     1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to empty.
     1. Return [=success=] with data `null`.
 

--- a/index.bs
+++ b/index.bs
@@ -4972,6 +4972,8 @@ Each <a>simulated Bluetooth adapter</a> has an <dfn>adapter state</dfn> that is 
   * "powered-off"
   * "absent"
 
+Each <a>simulated Bluetooth adapter</a> has a <dfn>le supported state</dfn> that is a boolean describing if the adapter supports Bluetooth Low Energy.
+
 A <dfn>simulated Bluetooth device</dfn> is a software defined [=Bluetooth device=] that behaves like a physical device, and may be attached to a <a>simulated Bluetooth adapter</a>, and may have associated properties like <a>Manufacturer Specific Data</a> and <a>Service UUIDs</a>.
 
 Issue: CDDL snippetes use the "text" type instead of
@@ -5191,7 +5193,9 @@ bluetooth.simulateAdapter = (
 
 bluetooth.SimulateAdapterParameters = {
    context: text,
-   state: "absent" / "powered-off" / "powered-on"
+   type: "create" / "update" / "remove",
+   ? leSupported: bool,
+   ? state: "absent" / "powered-off" / "powered-on"
 }
 </pre>
 
@@ -5201,22 +5205,66 @@ The [=remote end steps=] with command parameters |params| are:
 1. Let |contextId| be params["context"].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
-1. Let |simulatedBluetoothAdapter| be a new [=simulated Bluetooth adapter=].
-1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
-1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to |simulatedBluetoothAdapter|.
-1. Return [=success=] with data `null`.
+1. If |params|[`"type"`] is `create`, run the following steps:
+    1. If |params|[`"leSupported"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
+    1. If |params|[`"state"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
+    1. Let |simulatedBluetoothAdapter| be a new [=simulated Bluetooth adapter=].
+    1. Set |simulatedBluetoothAdapter|'s <a>le supported state</a> to |params|[`"leSupported"`].
+    1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
+    1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to |simulatedBluetoothAdapter|.
+    1. Return [=success=] with data `null`.
+1. If |params|[`"type"`] is `update`, run the following steps:
+    1. If |params|[`"state"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
+    1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
+    1. If |simulatedBluetoothAdapter| is empty, return [=error=] with [=error code=] [=invalid argument=].
+    1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
+    1. Return [=success=] with data `null`.
+1. If |params|[`"type"`] is `remove`, run the following steps:
+    1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to empty.
+    1. Return [=success=] with data `null`.
 
 </div>
 
 <div class="example">
-A [=local end=] could simulate an adapter by sending the following message:
+A [=local end=] could simulate an adapter that supports Bluetooth Low Energy by sending the following message:
 
 <pre highlight="json">
 {
   "method": "bluetooth.simulateAdapter",
   "params": {
     "context": "cxt-d03fdd81",
+    "type": "create",
+    "leSupported": true,
     "state": "powered-on",
+  }
+}
+</pre>
+</div>
+
+<div class="example">
+A [=local end=] could update the <a>adapter state</a> of an existing adapter by sending the following message:
+
+<pre highlight="json">
+{
+  "method": "bluetooth.simulateAdapter",
+  "params": {
+    "context": "cxt-d03fdd81",
+    "type": "update",
+    "state": "powered-off",
+  }
+}
+</pre>
+</div>
+
+<div class="example">
+A [=local end=] could remove an existing adapter by sending the following message:
+
+<pre highlight="json">
+{
+  "method": "bluetooth.simulateAdapter",
+  "params": {
+    "context": "cxt-d03fdd81",
+    "type": "remove",
   }
 }
 </pre>


### PR DESCRIPTION
Update `bluetooth.simulateAdapter` command to support creating, updating, and removing adapter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/646.html" title="Last updated on Feb 21, 2025, 10:23 PM UTC (6d9537f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/646/d2d4d06...chengweih001:6d9537f.html" title="Last updated on Feb 21, 2025, 10:23 PM UTC (6d9537f)">Diff</a>