### PR TITLE
Return error when type is not supported in bluetooth.simulateAdapter

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5228,6 +5228,7 @@ The [=remote end steps=] with command parameters |params| are:
     1. If |params|[`"state"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
     1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to empty.
     1. Return [=success=] with data `null`.
+1. Return [=error=] with [=error code=] [=invalid argument=].
 
 </div>
 


### PR DESCRIPTION
This patch specifies the behavior when the parameter of `type` of `bluetooth.simulateAdapter` is not supported.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/647.html" title="Last updated on Feb 28, 2025, 6:36 PM UTC (eb22999)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/647/6309029...chengweih001:eb22999.html" title="Last updated on Feb 28, 2025, 6:36 PM UTC (eb22999)">Diff</a>