### PR TITLE
New bluetooth.disableSimulation command for Web Bluetooth automation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5196,9 +5196,8 @@ bluetooth.simulateAdapter = (
 
 bluetooth.SimulateAdapterParameters = {
    context: text,
-   type: "create" / "update",
    ? leSupported: bool,
-   ? state: "absent" / "powered-off" / "powered-on"
+   state: "absent" / "powered-off" / "powered-on"
 }
 </pre>
 
@@ -5208,22 +5207,18 @@ The [=remote end steps=] with command parameters |params| are:
 1. Let |contextId| be |params|["context"].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
-1. If |params|[`"type"`] is `create`, run the following steps:
+1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
+1. If |simulatedBluetoothAdapter| is empty, run the following steps:
     1. If |params|[`"leSupported"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
-    1. If |params|[`"state"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
     1. Let |simulatedBluetoothAdapter| be a new [=simulated Bluetooth adapter=].
     1. Set |simulatedBluetoothAdapter|'s <a>LE supported state</a> to |params|[`"leSupported"`].
     1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
     1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to |simulatedBluetoothAdapter|.
     1. Return [=success=] with data `null`.
-1. If |params|[`"type"`] is `update`, run the following steps:
+1. If |simulatedBluetoothAdapter| is not empty, run the following steps:
     1. If |params|[`"leSupported"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
-    1. If |params|[`"state"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
-    1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
-    1. If |simulatedBluetoothAdapter| is empty, return [=error=] with [=error code=] [=invalid argument=].
     1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
     1. Return [=success=] with data `null`.
-1. Return [=error=] with [=error code=] [=invalid argument=].
 
 </div>
 
@@ -5235,7 +5230,6 @@ A [=local end=] could simulate an adapter that supports Bluetooth Low Energy by 
   "method": "bluetooth.simulateAdapter",
   "params": {
     "context": "cxt-d03fdd81",
-    "type": "create",
     "leSupported": true,
     "state": "powered-on",
   }
@@ -5251,7 +5245,6 @@ A [=local end=] could update the <a>adapter state</a> of an existing adapter by 
   "method": "bluetooth.simulateAdapter",
   "params": {
     "context": "cxt-d03fdd81",
-    "type": "update",
     "state": "powered-off",
   }
 }

--- a/index.bs
+++ b/index.bs
@@ -5209,7 +5209,7 @@ The [=remote end steps=] with command parameters |params| are:
 1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
 1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
 1. If |simulatedBluetoothAdapter| is empty, run the following steps:
-    1. If |params|[`"leSupported"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
+    1. If |params|[`"leSupported"`] does not [=map/exist=], set |params|[`"leSupported"`] to `true`.
     1. Let |simulatedBluetoothAdapter| be a new [=simulated Bluetooth adapter=].
     1. Set |simulatedBluetoothAdapter|'s <a>LE supported state</a> to |params|[`"leSupported"`].
     1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].

--- a/index.bs
+++ b/index.bs
@@ -5196,7 +5196,7 @@ bluetooth.simulateAdapter = (
 
 bluetooth.SimulateAdapterParameters = {
    context: text,
-   type: "create" / "update" / "remove",
+   type: "create" / "update",
    ? leSupported: bool,
    ? state: "absent" / "powered-off" / "powered-on"
 }
@@ -5205,7 +5205,7 @@ bluetooth.SimulateAdapterParameters = {
 <div algorithm="remote end steps for bluetooth.simulateAdapter">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be params["context"].
+1. Let |contextId| be |params|["context"].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
 1. If |params|[`"type"`] is `create`, run the following steps:
@@ -5222,11 +5222,6 @@ The [=remote end steps=] with command parameters |params| are:
     1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
     1. If |simulatedBluetoothAdapter| is empty, return [=error=] with [=error code=] [=invalid argument=].
     1. Set |simulatedBluetoothAdapter|'s <a>adapter state</a> to |params|[`"state"`].
-    1. Return [=success=] with data `null`.
-1. If |params|[`"type"`] is `remove`, run the following steps:
-    1. If |params|[`"leSupported"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
-    1. If |params|[`"state"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
-    1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to empty.
     1. Return [=success=] with data `null`.
 1. Return [=error=] with [=error code=] [=invalid argument=].
 
@@ -5263,15 +5258,38 @@ A [=local end=] could update the <a>adapter state</a> of an existing adapter by 
 </pre>
 </div>
 
+#### The bluetooth.disableSimulation Command #### {#bluetooth-disableSimulation-command}
+
+<pre highlight="cddl" class="cddl remote-cddl local-cddl">
+bluetooth.disableSimulation = (
+   method: "bluetooth.disableSimulation",
+   params: bluetooth.DisableSimulationParameters,
+)
+
+bluetooth.DisableSimulationParameters = {
+   context: text
+}
+</pre>
+
+<div algorithm="remote end steps for bluetooth.disableSimulation">
+The [=remote end steps=] with command parameters |params| are:
+
+1. Let |contextId| be |params|["context"].
+1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
+1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
+1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to empty.
+1. Return [=success=] with data `null`.
+
+</div>
+
 <div class="example">
-A [=local end=] could remove an existing adapter by sending the following message:
+A [=local end=] could disable the existing simulation by sending the following message:
 
 <pre highlight="json">
 {
-  "method": "bluetooth.simulateAdapter",
+  "method": "bluetooth.disableSimulation",
   "params": {
-    "context": "cxt-d03fdd81",
-    "type": "remove",
+    "context": "cxt-d03fdd81"
   }
 }
 </pre>

--- a/index.bs
+++ b/index.bs
@@ -123,6 +123,7 @@ spec: fingerprinting-guidance
         text: fingerprinting surface
 spec: html
     type: dfn
+        text: allowed to use; for :/
         text: associated navigator; for: /
         text: browsing context; for: /
         text: global object; for: /

--- a/scanning.bs
+++ b/scanning.bs
@@ -55,6 +55,9 @@ spec:dom
     type:dfn
         for:/
             text:document
+spec: html
+    type: dfn
+        text: allowed to use; for :/
 spec: webidl
     type: dfn
         text: resolve


### PR DESCRIPTION
This pull request moves `type` == `remove` from `bluetooth.simulateAdapter` to a new command `bluetooth.disableSimulation`. The goal is to make it clear that the effect of `bluetooth.simulateAdapter` would end up with a simulated adapter, while `bluetooth.disableSimulation` would remove the simulation entirely.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/648.html" title="Last updated on Mar 11, 2025, 1:40 AM UTC (fcdb0ee)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/648/22c5b49...chengweih001:fcdb0ee.html" title="Last updated on Mar 11, 2025, 1:40 AM UTC (fcdb0ee)">Diff</a>