### PR TITLE
build: extract aggregated `BluetoothCommand` cddl type

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5130,8 +5130,8 @@ This specification extends the set of [=error codes=] from
 <pre highlight="cddl" class="cddl remote-cddl local-cddl">
 BluetoothCommand = (
   bluetooth.HandleRequestDevicePrompt //
-  bluetooth.simulateAdapter //
-  bluetooth.disableSimulation //
+  bluetooth.SimulateAdapter //
+  bluetooth.DisableSimulation //
   bluetooth.SimulatePreconnectedPeripheral //
   bluetooth.SimulateAdvertisement //
 )
@@ -5200,7 +5200,7 @@ A [=local end=] could dismiss a prompt by sending the following message:
 #### The bluetooth.simulateAdapter Command #### {#bluetooth-simulateAdapter-command}
 
 <pre highlight="cddl" class="cddl remote-cddl local-cddl">
-bluetooth.simulateAdapter = (
+bluetooth.SimulateAdapter = (
    method: "bluetooth.simulateAdapter",
    params: bluetooth.SimulateAdapterParameters,
 )
@@ -5265,7 +5265,7 @@ A [=local end=] could update the <a>adapter state</a> of an existing adapter by 
 #### The bluetooth.disableSimulation Command #### {#bluetooth-disableSimulation-command}
 
 <pre highlight="cddl" class="cddl remote-cddl local-cddl">
-bluetooth.disableSimulation = (
+bluetooth.DisableSimulation = (
    method: "bluetooth.disableSimulation",
    params: bluetooth.DisableSimulationParameters,
 )

--- a/index.bs
+++ b/index.bs
@@ -5127,6 +5127,16 @@ This specification extends the set of [=error codes=] from
 
 ### Commands ### {#bidi-commands}
 
+<pre highlight="cddl" class="cddl remote-cddl local-cddl">
+BluetoothCommand = (
+  bluetooth.HandleRequestDevicePrompt //
+  bluetooth.simulateAdapter //
+  bluetooth.disableSimulation //
+  bluetooth.SimulatePreconnectedPeripheral //
+  bluetooth.SimulateAdvertisement //
+)
+</pre>
+
 #### The bluetooth.handleRequestDevicePrompt Command #### {#bluetooth-handlerequestdeviceprompt-command}
 
 <pre highlight="cddl" class="cddl remote-cddl local-cddl">


### PR DESCRIPTION
Required for proper handling WeebDriver BiDi commands.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/sadym-chromium/web-bluetooth/pull/649.html" title="Last updated on Mar 26, 2025, 10:31 PM UTC (c53088a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/649/7066ce3...sadym-chromium:c53088a.html" title="Last updated on Mar 26, 2025, 10:31 PM UTC (c53088a)">Diff</a>