### PR TITLE
bluetooth.gattConnectionAttempted and bluetooth.simulateGattConnectionResponse for Web Bluetooth automation

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -3144,10 +3144,12 @@ method, when invoked, MUST perform the following steps:
             [=Window/navigable=] and [=this=].{{BluetoothRemoteGATTServer/device}}.
         1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `null`, wait for
             it to be non-`null`.
-        1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is not `0`, do the
+        1. Let |response| be [=this=].{{[[automatedGATTConnectionResponse]]}}.
+        1. Set [=this=].{{[[automatedGATTConnectionResponse]]}} to `null`.
+        1. If |response| is not `0`, do the
             following sub-steps:
             1. Remove |promise| from [=this=].{{[[activeAlgorithms]]}}.
-            1. [=queue a global task=] on the [=Bluetooth task source=] given
+            1. [=Queue a global task=] on the [=Bluetooth task source=] given
                 |global| to [=reject=] |promise| with a "{{NetworkError}}"
                 {{DOMException}} and abort these steps.
     1. Otherwise, run the following steps:
@@ -5527,8 +5529,8 @@ To <dfn>trigger a prompt updated event</dfn> given a [=navigable=] |navigable|, 
 1. Set [=map of navigables to device prompts=][|navigableId|] to |prompt|.
 1. Let |params| be a [=map=] matching the <code>bluetooth.RequestDevicePromptUpdatedParameters</code> production with the <code>context</code> field set to |navigableId|, the <code>prompt</code> field set to |promptId|, and the <code>devices</code> field set to |serialized devices|.
 1. Let |body| be a [=map=] matching the <code>bluetooth.RequestDevicePromptUpdated</code> production, with the <code>params</code> field set to |params|.
-1. Let |related navigables| be a [=/set=] containing |navigable|.
-1. For each |session| in the [=set of sessions for which an event is enabled=] given "<code>bluetooth.requestDevicePromptUpdated</code>" and |related navigables|:
+1. Let |relatedNavigables| be a [=/set=] containing |navigable|.
+1. For each |session| in the [=set of sessions for which an event is enabled=] given "<code>bluetooth.requestDevicePromptUpdated</code>" and |relatedNavigables|:
     1. [=Emit an event=] with |session| and |body|.
 
 </div>
@@ -5552,12 +5554,12 @@ To <dfn>trigger a gatt connection attempted event</dfn> given a [=navigable=] |n
 
 1. Let |navigableId| be |navigable|'s [=navigable id=].
 1. Let |params| be a [=map=] matching the <code>bluetooth.GattConnectionAttemptedParameters</code> production with the
-    <code>context</code> field set to |navigableId|, the <code>address</code> field set to |device|.{{[[representedDevice]]}}'s address.
+    <code>context</code> field set to |navigableId| and the <code>address</code> field set to |device|.{{[[representedDevice]]}}'s address.
 1. Let |body| be a [=map=] matching the <code>bluetooth.GattConnectionAttempted</code> production, with the
     <code>params</code> field set to |params|.
-1. Let |related navigables| be a [=/set=] containing |navigable|.
+1. Let |relatedNavigables| be a [=/set=] containing |navigable|.
 1. For each |session| in the [=set of sessions for which an event is enabled=] given
-    "<code>bluetooth.gattEventGenerated</code>" and |related navigables|:
+    "<code>bluetooth.gattEventGenerated</code>" and |relatedNavigables|:
     1. [=Emit an event=] with |session| and |body|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -110,6 +110,7 @@ spec: WEBDRIVER; urlPrefix: https://w3c.github.io/webdriver/
     type: dfn
         text: error; url: dfn-error
         text: local end; url: dfn-local-ends
+        text: invalid element state; url: dfn-invalid-element-state
 
 </pre>
 <pre class="link-defaults">
@@ -3113,7 +3114,7 @@ slots</a> described in the following table:
   </tr>
   <tr>
     <td><dfn>\[[automatedGATTConnectionResponse]]</dfn></td>
-    <td><code>null</code></td>
+    <td><code>"not-expected"</code></td>
     <td>
       The simulated GATT connection response code for a GATT connection attempt.
     </td>
@@ -3142,10 +3143,12 @@ method, when invoked, MUST perform the following steps:
         is not empty, run the following steps:
         1. [=Trigger a gatt connection attempted event=] given |global|'s
             [=Window/navigable=] and [=this=].{{BluetoothRemoteGATTServer/device}}.
-        1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `null`, wait for
-            it to be non-`null`.
+        1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `"not-expected"`,
+            set it to `"expected"`.
+        1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `"expected"`,
+            wait for it to be changed.
         1. Let |response| be [=this=].{{[[automatedGATTConnectionResponse]]}}.
-        1. Set [=this=].{{[[automatedGATTConnectionResponse]]}} to `null`.
+        1. Set [=this=].{{[[automatedGATTConnectionResponse]]}} to `"not-expected"`.
         1. If |response| is not `0`, do the
             following sub-steps:
             1. Remove |promise| from [=this=].{{[[activeAlgorithms]]}}.
@@ -5483,7 +5486,9 @@ The [=remote end steps=] with command parameters |params| are:
 1. Let |simulatedDeviceInstance| be the result of <a>get the <code>BluetoothDevice</code> representing</a>
     |simulatedDevice| inside |navigable|'s <a>active window</a>'s <a spec=HTML>associated <code>Navigator</code></a>'s
     [=associated Bluetooth=].
-1. Set |simulatedDeviceInstance|.{{[[gatt]]}}.{{[[automatedGATTConnectionResponse]]}} to |params|[`"code"`].
+1. If |simulatedDeviceInstance|.{{[[gatt]]}}.{{[[automatedGATTConnectionResponse]]}} is `"expected"`,
+    set |simulatedDeviceInstance|.{{[[gatt]]}}.{{[[automatedGATTConnectionResponse]]}} to |params|[`"code"`].
+1. Otherwise, return [=error=] with [=error code=] [=invalid element state=].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -2915,25 +2915,6 @@ To <dfn>query the Bluetooth cache</dfn> in a {{BluetoothDevice}} instance
 [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
 1. Let |global| be |deviceObj|'s [=relevant global object=].
-1. If |global|'s [=Window/navigable=]'s [=navigable/top-level traversable=]'s
-    <a>simulated Bluetooth adapter</a> is not empty, run the following steps:
-    1. [=Trigger a gatt event=] given |global|'s [=Window/navigable=], |deviceObj|,
-        and <code>"discovery"</code>.
-    1. Let |pendingAutomationPromise| be a [=a new promise=].
-    1. Add |pendingAutomationPromise| to [=this=].{{[[pendingAutomationResponse]]}}.
-    1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |params|,
-        run the following steps:
-        1. Remove |pendingAutomationPromise| from [=this=].{{[[pendingAutomationResponse]]}}.
-        1. If |params|[`"type"`] is `discovery` and |params|[`"code"`] is `0`, do the
-            following sub-steps:
-            1. Let |result| be a new sequence.
-            1. Append to |result| the <code>Promise&lt;BluetoothGATT*></code>
-                instance in |context|.{{Bluetooth/[[attributeInstanceMap]]}} matching the
-                description.
-            1. [=resolve=] |promise| with the result of [=waiting for all=] elements of
-                |result|.
-        1. Otherwise,  [=reject=] |promise| with a {{NetworkError}}.
-    1. Abort these steps.
 1. [=Populate the Bluetooth cache=] with entries matching the description.
 1. If the previous step returns an error, [=queue a global task=] on the
     [=Bluetooth task source=] given |global| to [=reject=] |promise| with that
@@ -3131,11 +3112,11 @@ slots</a> described in the following table:
     </td>
   </tr>
   <tr>
-    <td><dfn>\[[pendingAutomationResponse]]</dfn></td>
+    <td><dfn>\[[pendingAutomationGATTConnectionResponse]]</dfn></td>
     <td><code>new {{Set}}()</code></td>
     <td>
-      Contains a {{Promise}} corresponding to each algorithm that is waiting for
-      the automation script to provide a response.
+      Contains {{promise}}s that are waiting for the automation script to provide
+      the response for a GATT connection attempt
     </td>
   </tr>
 </table>
@@ -3159,14 +3140,14 @@ method, when invoked, MUST perform the following steps:
 1. If |global|'s [=Window/navigable=]'s
     [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a> is
     not empty, run the following steps:
-    1. [=Trigger a gatt event=] given |global|'s [=Window/navigable=],
-        [=this=].{{BluetoothRemoteGATTServer/device}}, and <code>"connect"</code>.
+    1. [=Trigger a gatt connection attempted event=] given |global|'s [=Window/navigable=]
+        and [=this=].{{BluetoothRemoteGATTServer/device}}.
     1. Let |pendingAutomationPromise| be a [=a new promise=].
-    1. Add |pendingAutomationPromise| to [=this=].{{[[pendingAutomationResponse]]}}.
-    1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |params|,
+    1. Add |pendingAutomationPromise| to
+        [=this=].{{[[pendingAutomationGATTConnectionResponse]]}}.
+    1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |responseCode|,
         run the following steps:
-        1. If |params|[`"type"`] is `connection` and |params|[`"code"`] is `0`,
-            do the following sub-steps:
+        1. If |responseCode| is `0`, do the following sub-steps:
             1. Set [=this=].{{BluetoothRemoteGATTServer/connected}} to `true`.
             1. [=Resolve=] |promise| with [=this=].
         1. Otherwise, [=reject=] |promise| with  {{NetworkError}}.
@@ -5471,24 +5452,23 @@ A [=local end=] could simulate a device advertisement by sending the following m
 </pre>
 </div>
 
-#### The bluetooth.simulateGattResponse Command #### {#bluetooth-simulategattresponse-command}
+#### The bluetooth.simulateGattConnectionResponse Command #### {#bluetooth-simulategattconnectionresponse-command}
 
 <pre highlight="cddl" class="cddl remote-cddl local-cddl">
-bluetooth.SimulateGattResponse = (
-   method: "bluetooth.simulateGattResponse",
-   params: bluetooth.SimulateGattResponseParameters,
+bluetooth.SimulateGattConnectionResponse = (
+   method: "bluetooth.simulateGattConnectionResponse",
+   params: bluetooth.SimulateGattConnectionResponseParameters,
 )
 
-bluetooth.SimulateGattResponseParameters = {
+bluetooth.SimulateGattConnectionResponseParameters = {
    context: text,
    address: text,
-   type: "connection" / "discovery",
    code: uint
 }
 
 </pre>
 
-<div algorithm="remote end steps for bluetooth.simulateGattResponse">
+<div algorithm="remote end steps for bluetooth.simulateGattConnectionResponse">
 The [=remote end steps=] with command parameters |params| are:
 
 1. Let |contextId| be |params|["context"].
@@ -5503,7 +5483,7 @@ The [=remote end steps=] with command parameters |params| are:
     |simulatedDevice| inside |navigable|'s <a>active window</a>'s <a spec=HTML>associated <code>Navigator</code></a>'s
     [=associated Bluetooth=].
 1. Let |gatt| be |simulatedDeviceInstance|.{{[[gatt]]}}.
-1. For each |promise| in |gatt|.{{[[pendingAutomationResponse]]}}, [=resolve=] |promise| with |params|.
+1. For each |promise| in |gatt|.{{[[pendingAutomationGATTConnectionResponse]]}}, [=resolve=] |promise| with |params|[`code`].
 
 </div>
 
@@ -5513,28 +5493,10 @@ A [=local end=] could simulate a device gatt connection response of success
 
 <pre highlight="json">
 {
-  "method": "bluetooth.simulateGattResponse",
+  "method": "bluetooth.simulateGattConnectionResponse",
   "params": {
     "context": "cxt-d03fdd81",
     "address": "09:09:09:09:09:09",
-    "type": "connection",
-    "code": 0
-  }
-}
-</pre>
-</div>
-
-<div class="example">
-A [=local end=] could simulate a device gatt service discovery response of success
-(error code `0x00` according to <a>List of Error Codes</a>) by sending the following message:
-
-<pre highlight="json">
-{
-  "method": "bluetooth.simulateGattResponse",
-  "params": {
-    "context": "cxt-d03fdd81",
-    "address": "09:09:09:09:09:09",
-    "type": "discovery"
     "code": 0
   }
 }
@@ -5573,29 +5535,27 @@ To <dfn>trigger a prompt updated event</dfn> given a [=navigable=] |navigable|, 
 
 </div>
 
-#### The bluetooth.gattEventGenerated Event #### {#bluetooth-gatteventgenerated-event}
+#### The bluetooth.gattConnectionAttempted Event #### {#bluetooth-gattConnectionAttempted-event}
 
 <pre highlight="cddl" class="cddl local-cddl">
-bluetooth.GattEventGenerated = (
-   method: "bluetooth.gattEventGenerated",
-   params: bluetooth.GattEventGeneratedParameters
+bluetooth.GattConnectionAttempted = (
+   method: "bluetooth.gattConnectionAttempted",
+   params: bluetooth.GattConnectionAttemptedParameters
 )
 
-bluetooth.GattEventGeneratedParameters = {
+bluetooth.GattConnectionAttemptedParameters = {
    context: text,
-   address: text,
-   type: "connection" / "discovery",
+   address: text
 }
 </pre>
 
-<div algorithm="remote end event trigger for bluetooth.GattEventGenerated">
-To <dfn>trigger a gatt event</dfn> given a [=navigable=] |navigable|, a {{BluetoothDevice}} |device|, and |type|:
+<div algorithm="remote end event trigger for bluetooth.GattConnectionAttempted">
+To <dfn>trigger a gatt connection attempted event</dfn> given a [=navigable=] |navigable| and a {{BluetoothDevice}} |device|:
 
 1. Let |navigableId| be |navigable|'s [=navigable id=].
-1. Let |params| be a [=map=] matching the <code>bluetooth.GattEventGeneratedParameters</code> production with the
-    <code>context</code> field set to |navigableId|, the <code>address</code> field set to |device|.{{[[representedDevice]]}}'s address, and the
-    <code>type</code> field set to |type|.
-1. Let |body| be a [=map=] matching the <code>bluetooth.GattEventGenerated</code> production, with the
+1. Let |params| be a [=map=] matching the <code>bluetooth.GattConnectionAttemptedParameters</code> production with the
+    <code>context</code> field set to |navigableId|, the <code>address</code> field set to |device|.{{[[representedDevice]]}}'s address.
+1. Let |body| be a [=map=] matching the <code>bluetooth.GattConnectionAttempted</code> production, with the
     <code>params</code> field set to |params|.
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 1. For each |session| in the [=set of sessions for which an event is enabled=] given

--- a/index.bs
+++ b/index.bs
@@ -3147,6 +3147,12 @@ method, when invoked, MUST perform the following steps:
         [=this=].{{[[pendingAutomationGATTConnectionResponse]]}}.
     1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |responseCode|,
         run the following steps:
+        1. If |promise| is not in [=this=].{{[[activeAlgorithms]]}}, [=reject=]
+            |promise| with an "{{AbortError}}" {{DOMException}},
+            [=garbage-collect the connection=] of
+            [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}},
+            and abort these steps.
+        1. Remove |promise| from [=this=].{{[[activeAlgorithms]]}}.        
         1. If |responseCode| is `0`, do the following sub-steps:
             1. Set [=this=].{{BluetoothRemoteGATTServer/connected}} to `true`.
             1. [=Resolve=] |promise| with [=this=].

--- a/index.bs
+++ b/index.bs
@@ -2915,9 +2915,8 @@ To <dfn>query the Bluetooth cache</dfn> in a {{BluetoothDevice}} instance
 [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
 1. Let |global| be |deviceObj|'s [=relevant global object=].
-1. Let |simulatedBluetoothAdapter| be |deviceObj|'s [=Window/navigable=]'s
-    [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a>.
-1. If |simulatedBluetoothAdapter| is not empty, run the following steps:
+1. If |deviceObj|'s [=Window/navigable=]'s [=navigable/top-level traversable=]'s
+    <a>simulated Bluetooth adapter</a> is not empty, run the following steps:
     1. [=Trigger a gatt event=] given |deviceObj|'s [=Window/navigable=], |deviceObj|,
         and <code>"discovery"</code>.
     1. <a>Upon fulfillment</a> of <var>promise</var> with |params|, run the
@@ -2928,7 +2927,7 @@ To <dfn>query the Bluetooth cache</dfn> in a {{BluetoothDevice}} instance
             1. Append to |result| the <code>Promise&lt;BluetoothGATT*></code>
                 instance in |context|.{{Bluetooth/[[attributeInstanceMap]]}} matching the
                 description.
-            1. Return |result|.
+            1. Return the result of [=waiting for all=] elements of |result|.
         1. Otherwise, throw a {{NetworkError}}.
     1. Abort these steps.
 1. [=Populate the Bluetooth cache=] with entries matching the description.
@@ -3145,17 +3144,18 @@ method, when invoked, MUST perform the following steps:
     and/or give the user a way to retry failed operations.
 1. Let |promise| be [=a new promise=].
 1. Add |promise| to [=this=].{{[[activeAlgorithms]]}}.
-1. Let |simulatedBluetoothAdapter| be [=this=]'s [=Window/navigable=]'s
-    [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a>.
-1. If |simulatedBluetoothAdapter| is not empty,
+1. If [=this=]'s [=Window/navigable=]'s
+    [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a> is
+    not empty, run the following steps:
     1. [=Trigger a gatt event=] given [=this=]'s [=Window/navigable=],
         [=this=].{{BluetoothRemoteGATTServer/device}}, and <code>"connect"</code>.
     1. <a>Upon fulfillment</a> of <var>promise</var> with |params|, run the
         following steps:
-        1. If |params|[`"type"`] is `connection` and |params|[`"code"`] is `0`, do the following sub-steps:
-            1. Set |gatt|.{{BluetoothRemoteGATTServer/connected}} to `true`.
-            1. [=Resolve=] |promise| with |gatt|.
-        1. Otherwise, [=reject=] |promise| with {{NetworkError}}.
+        1. If |params|[`"type"`] is `connection` and |params|[`"code"`] is `0`,
+            do the following sub-steps:
+            1. Set [=this=].{{BluetoothRemoteGATTServer/connected}} to `true`.
+            1. return [=this=].
+        1. Otherwise, throw a {{NetworkError}}.
     1. Return |promise|.
 1. Run the following steps [=in parallel=]:
     1. If [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}}
@@ -5489,12 +5489,14 @@ The [=remote end steps=] with command parameters |params| are:
     |simulatedDevice| inside |navigable|'s <a>active window</a>'s <a spec=HTML>associated <code>Navigator</code></a>'s
     [=associated Bluetooth=].
 1. Let |gatt| be |simulatedDeviceInstance|.{{[[gatt]]}}.
-1. For each |promise| in |gatt|.{{[[activeAlgorithms]]}}, [=resolve=] |promise| with |params|.
+1. For each |promise| in |gatt|.{{[[activeAlgorithms]]}}, [=resolve=] |promise| with |params| and remove |promise|
+    from |gatt|.{{[[activeAlgorithms]]}}.
 
 </div>
 
 <div class="example">
-A [=local end=] could simulate a device gatt connection response by sending the following message:
+A [=local end=] could simulate a device gatt connection response of success
+(error code `0x00` according to <a>List of Error Codes</a>) by sending the following message:
 
 <pre highlight="json">
 {
@@ -5502,14 +5504,16 @@ A [=local end=] could simulate a device gatt connection response by sending the 
   "params": {
     "context": "cxt-d03fdd81",
     "address": "09:09:09:09:09:09",
-    "type": "connection"
+    "type": "connection",
+    "code": 0
   }
 }
 </pre>
 </div>
 
 <div class="example">
-A [=local end=] could simulate a device gatt service discovery response by sending the following message:
+A [=local end=] could simulate a device gatt service discovery response of success
+(error code `0x00` according to <a>List of Error Codes</a>) by sending the following message:
 
 <pre highlight="json">
 {
@@ -5518,6 +5522,7 @@ A [=local end=] could simulate a device gatt service discovery response by sendi
     "context": "cxt-d03fdd81",
     "address": "09:09:09:09:09:09",
     "type": "discovery"
+    "code": 0
   }
 }
 </pre>
@@ -5571,11 +5576,11 @@ bluetooth.GattEventGeneratedParameters = {
 </pre>
 
 <div algorithm="remote end event trigger for bluetooth.GattEventGenerated">
-To <dfn>trigger a gatt event</dfn> given a [=navigable=] |navigable|, a [=Bluetooth device=] |device|, and |type|:
+To <dfn>trigger a gatt event</dfn> given a [=navigable=] |navigable|, a {{BluetoothDevice}} |device|, and |type|:
 
 1. Let |navigableId| be |navigable|'s [=navigable id=].
 1. Let |params| be a [=map=] matching the <code>bluetooth.GattEventGeneratedParameters</code> production with the
-    <code>context</code> field set to |navigableId|, the <code>address</code> field set to |device|'s address, and the
+    <code>context</code> field set to |navigableId|, the <code>address</code> field set to |device|.{{[[representedDevice]]}}'s address, and the
     <code>type</code> field set to |type|.
 1. Let |body| be a [=map=] matching the <code>bluetooth.GattEventGenerated</code> production, with the
     <code>params</code> field set to |params|.
@@ -5651,6 +5656,15 @@ This specification uses a read-only type that is similar to WebIDL's
       </li>
       <li value="2">Core System Package [BR/EDR Controller volume]
         <ol type="A">
+          <li value="4">Error Codes
+            <ol>
+              <li value="1">Overview of Error Codes
+                <ol>
+                  <li value="3"><dfn>List of Error Codes</dfn></li>
+                </ol>
+              </li>
+            </ol>
+          </li>
           <li value="5">Host Controller Interface Functional Specification
             <ol>
               <li value="7">HCI Commands and Events

--- a/index.bs
+++ b/index.bs
@@ -3112,11 +3112,10 @@ slots</a> described in the following table:
     </td>
   </tr>
   <tr>
-    <td><dfn>\[[pendingAutomationGATTConnectionResponse]]</dfn></td>
-    <td><code>new {{Set}}()</code></td>
+    <td><dfn>\[[automatedGATTConnectionResponse]]</dfn></td>
+    <td><code>null</code></td>
     <td>
-      Contains {{promise}}s that are waiting for the automation script to provide
-      the response for a GATT connection attempt
+      The simulated GATT connection response code for a GATT connection attempt.
     </td>
   </tr>
 </table>
@@ -3137,65 +3136,58 @@ method, when invoked, MUST perform the following steps:
     and/or give the user a way to retry failed operations.
 1. Let |promise| be [=a new promise=].
 1. Add |promise| to [=this=].{{[[activeAlgorithms]]}}.
-1. If |global|'s [=Window/navigable=]'s
-    [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a> is
-    not empty, run the following steps:
-    1. [=Trigger a gatt connection attempted event=] given |global|'s [=Window/navigable=]
-        and [=this=].{{BluetoothRemoteGATTServer/device}}.
-    1. Let |pendingAutomationPromise| be a [=a new promise=].
-    1. Add |pendingAutomationPromise| to
-        [=this=].{{[[pendingAutomationGATTConnectionResponse]]}}.
-    1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |responseCode|,
-        run the following steps:
-        1. If |promise| is not in [=this=].{{[[activeAlgorithms]]}}, [=reject=]
-            |promise| with an "{{AbortError}}" {{DOMException}},
-            [=garbage-collect the connection=] of
-            [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}},
-            and abort these steps.
-        1. Remove |promise| from [=this=].{{[[activeAlgorithms]]}}.        
-        1. If |responseCode| is `0`, do the following sub-steps:
-            1. Set [=this=].{{BluetoothRemoteGATTServer/connected}} to `true`.
-            1. [=Resolve=] |promise| with [=this=].
-        1. Otherwise, [=reject=] |promise| with  {{NetworkError}}.
-    1. Return |promise|.
 1. Run the following steps [=in parallel=]:
-    1. If [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}}
-        has no [=ATT Bearer=], do the following sub-steps:
-        1. <p id="create-an-att-bearer">Attempt to create an <a>ATT Bearer</a>
-            using the procedures described in "Connection Establishment" under
-            <a>GAP Interoperability Requirements</a>. Abort this attempt if
-            |promise| is removed from
-            [=this=].{{[[activeAlgorithms]]}}.</p>
+    1. If |global|'s [=Window/navigable=]'s
+        [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a>
+        is not empty, run the following steps:
+        1. [=Trigger a gatt connection attempted event=] given |global|'s
+            [=Window/navigable=] and [=this=].{{BluetoothRemoteGATTServer/device}}.
+        1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `null`, wait for
+            it to be non-`null`.
+        1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is not `0`, do the
+            following sub-steps:
+            1. Remove |promise| from [=this=].{{[[activeAlgorithms]]}}.
+            1. [=queue a global task=] on the [=Bluetooth task source=] given
+                |global| to [=reject=] |promise| with a "{{NetworkError}}"
+                {{DOMException}} and abort these steps.
+    1. Otherwise, run the following steps:
+        1. If [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}}
+            has no [=ATT Bearer=], do the following sub-steps:
+            1. <p id="create-an-att-bearer">Attempt to create an <a>ATT Bearer</a>
+                using the procedures described in "Connection Establishment" under
+                <a>GAP Interoperability Requirements</a>. Abort this attempt if
+                |promise| is removed from
+                [=this=].{{[[activeAlgorithms]]}}.</p>
 
-            <div class="note">
-              Note: These procedures can wait forever
-              if a connectable advertisement isn't received.
-              The website should call {{disconnect()}}
-              if it no longer wants to connect.
-            </div>
-        1. If this attempt was aborted because |promise| was removed from
-            [=this=].{{[[activeAlgorithms]]}}, [=queue a global task=] on
-            the [=Bluetooth task source=] given |global| to [=reject=]
-            |promise| with an "{{AbortError}}" {{DOMException}} and abort these
-            steps.
-        1. If this attempt failed for another reason, [=queue a global task=]
-            on the [=Bluetooth task source=] given |global| to [=reject=]
-            |promise| with a "{{NetworkError}}" {{DOMException}} and abort
-            these steps.
-        1. Use the [=Exchange MTU=] procedure to negotiate the largest
-            supported MTU. Ignore any errors from this step.
-        1. The UA MAY attempt to bond with the remote device using the <a>BR/EDR
-            Bonding Procedure</a> or the [=LE Bonding Procedure=].
+                <div class="note">
+                  Note: These procedures can wait forever
+                  if a connectable advertisement isn't received.
+                  The website should call {{disconnect()}}
+                  if it no longer wants to connect.
+                </div>
+            1. If this attempt was aborted because |promise| was removed from
+                [=this=].{{[[activeAlgorithms]]}}, [=queue a global task=] on
+                the [=Bluetooth task source=] given |global| to [=reject=]
+                |promise| with an "{{AbortError}}" {{DOMException}} and abort these
+                steps.
+            1. If this attempt failed for another reason, [=queue a global task=]
+                on the [=Bluetooth task source=] given |global| to [=reject=]
+                |promise| with a "{{NetworkError}}" {{DOMException}} and abort
+                these steps.
+            1. Use the [=Exchange MTU=] procedure to negotiate the largest
+                supported MTU. Ignore any errors from this step.
+            1. The UA MAY attempt to bond with the remote device using the <a>BR/EDR
+                Bonding Procedure</a> or the [=LE Bonding Procedure=].
 
-            Note: We would normally prefer to give the website control over
-            whether and when bonding happens, but the [Core
-            Bluetooth](https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/AboutCoreBluetooth/Introduction.html)
-            platform API doesn't provide a way for UAs to implement such a knob.
-            Having a bond is more secure than not having one, so this
-            specification allows the UA to opportunistically create one on
-            platforms where that's possible. This may cause a user-visible
-            pairing dialog to appear when a connection is created, instead of
-            when a restricted characteristic is accessed.
+                Note: We would normally prefer to give the website control over
+                whether and when bonding happens, but the [Core
+                Bluetooth](https://developer.apple.com/library/content/documentation/NetworkingInternetWeb/Conceptual/CoreBluetooth_concepts/AboutCoreBluetooth/Introduction.html)
+                platform API doesn't provide a way for UAs to implement such a knob.
+                Having a bond is more secure than not having one, so this
+                specification allows the UA to opportunistically create one on
+                platforms where that's possible. This may cause a user-visible
+                pairing dialog to appear when a connection is created, instead of
+                when a restricted characteristic is accessed.
     1. [=Queue a global task=] on the [=Bluetooth task source=] given |global|
         to perform the following sub-steps:
         1. If |promise| is not in [=this=].{{[[activeAlgorithms]]}}, [=reject=]
@@ -5163,6 +5155,7 @@ BluetoothCommand = (
   bluetooth.DisableSimulation //
   bluetooth.SimulatePreconnectedPeripheral //
   bluetooth.SimulateAdvertisement //
+  bluetooth.SimulateGattConnectionResponse //
 )
 </pre>
 
@@ -5244,7 +5237,7 @@ bluetooth.SimulateAdapterParameters = {
 <div algorithm="remote end steps for bluetooth.simulateAdapter">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be |params|["context"].
+1. Let |contextId| be |params|[`"context"`].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
 1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
@@ -5307,7 +5300,7 @@ bluetooth.DisableSimulationParameters = {
 <div algorithm="remote end steps for bluetooth.disableSimulation">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be |params|["context"].
+1. Let |contextId| be |params|[`"context"`].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |navigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
 1. Set |navigable|'s <a>simulated Bluetooth adapter</a> to empty.
@@ -5409,7 +5402,7 @@ bluetooth.SimulateAdvertisementScanEntryParameters = {
 <div algorithm="remote end steps for bluetooth.simulateAdvertisement">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be |params|["context"].
+1. Let |contextId| be |params|[`"context"`].
 1. Let |topLevelNavigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |topLevelNavigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
 1. Let |scanEntry| be |params|[`"scanEntry"`].
@@ -5477,7 +5470,7 @@ bluetooth.SimulateGattConnectionResponseParameters = {
 <div algorithm="remote end steps for bluetooth.simulateGattConnectionResponse">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be |params|["context"].
+1. Let |contextId| be |params|[`"context"`].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. Let |deviceAddress| be |params|[`"address"`].
 1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
@@ -5488,8 +5481,7 @@ The [=remote end steps=] with command parameters |params| are:
 1. Let |simulatedDeviceInstance| be the result of <a>get the <code>BluetoothDevice</code> representing</a>
     |simulatedDevice| inside |navigable|'s <a>active window</a>'s <a spec=HTML>associated <code>Navigator</code></a>'s
     [=associated Bluetooth=].
-1. Let |gatt| be |simulatedDeviceInstance|.{{[[gatt]]}}.
-1. For each |promise| in |gatt|.{{[[pendingAutomationGATTConnectionResponse]]}}, [=resolve=] |promise| with |params|[`code`].
+1. Set |simulatedDeviceInstance|.{{[[gatt]]}}.{{[[automatedGATTConnectionResponse]]}} to |params|[`"code"`].
 
 </div>
 

--- a/index.bs
+++ b/index.bs
@@ -3136,6 +3136,8 @@ method, when invoked, MUST perform the following steps:
     but for now sites need to serialize their use of this API
     and/or give the user a way to retry failed operations.
 1. Let |promise| be [=a new promise=].
+1. If [=this=].{{BluetoothRemoteGATTServer/connected}} is `true`,
+    [=resolve=] |promise| with [=this=] and return |promise|.
 1. Add |promise| to [=this=].{{[[activeAlgorithms]]}}.
 1. Run the following steps [=in parallel=]:
     1. If |global|'s [=Window/navigable=]'s
@@ -3146,7 +3148,7 @@ method, when invoked, MUST perform the following steps:
         1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `"not-expected"`,
             set it to `"expected"`.
         1. If [=this=].{{[[automatedGATTConnectionResponse]]}} is `"expected"`,
-            wait for it to be changed.
+            wait for it to change.
         1. Let |response| be [=this=].{{[[automatedGATTConnectionResponse]]}}.
         1. Set [=this=].{{[[automatedGATTConnectionResponse]]}} to `"not-expected"`.
         1. If |response| is not `0`, do the

--- a/index.bs
+++ b/index.bs
@@ -2915,6 +2915,22 @@ To <dfn>query the Bluetooth cache</dfn> in a {{BluetoothDevice}} instance
 [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
 1. Let |global| be |deviceObj|'s [=relevant global object=].
+1. Let |simulatedBluetoothAdapter| be |deviceObj|'s [=Window/navigable=]'s
+    [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a>.
+1. If |simulatedBluetoothAdapter| is not empty, run the following steps:
+    1. [=Trigger a gatt event=] given |deviceObj|'s [=Window/navigable=], |deviceObj|,
+        and <code>"discovery"</code>.
+    1. <a>Upon fulfillment</a> of <var>promise</var> with |params|, run the
+        following steps:
+        1. If |params|[`"type"`] is `discovery` and |params|[`"code"`] is `0`, do the
+            following sub-steps:
+            1. Let |result| be a new sequence.
+            1. Append to |result| the <code>Promise&lt;BluetoothGATT*></code>
+                instance in |context|.{{Bluetooth/[[attributeInstanceMap]]}} matching the
+                description.
+            1. Return |result|.
+        1. Otherwise, throw a {{NetworkError}}.
+    1. Abort these steps.
 1. [=Populate the Bluetooth cache=] with entries matching the description.
 1. If the previous step returns an error, [=queue a global task=] on the
     [=Bluetooth task source=] given |global| to [=reject=] |promise| with that
@@ -3129,6 +3145,18 @@ method, when invoked, MUST perform the following steps:
     and/or give the user a way to retry failed operations.
 1. Let |promise| be [=a new promise=].
 1. Add |promise| to [=this=].{{[[activeAlgorithms]]}}.
+1. Let |simulatedBluetoothAdapter| be [=this=]'s [=Window/navigable=]'s
+    [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a>.
+1. If |simulatedBluetoothAdapter| is not empty,
+    1. [=Trigger a gatt event=] given [=this=]'s [=Window/navigable=],
+        [=this=].{{BluetoothRemoteGATTServer/device}}, and <code>"connect"</code>.
+    1. <a>Upon fulfillment</a> of <var>promise</var> with |params|, run the
+        following steps:
+        1. If |params|[`"type"`] is `connection` and |params|[`"code"`] is `0`, do the following sub-steps:
+            1. Set |gatt|.{{BluetoothRemoteGATTServer/connected}} to `true`.
+            1. [=Resolve=] |promise| with |gatt|.
+        1. Otherwise, [=reject=] |promise| with {{NetworkError}}.
+    1. Return |promise|.
 1. Run the following steps [=in parallel=]:
     1. If [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}}
         has no [=ATT Bearer=], do the following sub-steps:
@@ -5429,6 +5457,72 @@ A [=local end=] could simulate a device advertisement by sending the following m
 </pre>
 </div>
 
+#### The bluetooth.simulateGattResponse Command #### {#bluetooth-simulategattresponse-command}
+
+<pre highlight="cddl" class="cddl remote-cddl local-cddl">
+bluetooth.SimulateGattResponse = (
+   method: "bluetooth.simulateGattResponse",
+   params: bluetooth.SimulateGattResponseParameters,
+)
+
+bluetooth.SimulateGattResponseParameters = {
+   context: text,
+   address: text,
+   type: "connection" / "discovery",
+   code: uint
+}
+
+</pre>
+
+<div algorithm="remote end steps for bluetooth.simulateGattResponse">
+The [=remote end steps=] with command parameters |params| are:
+
+1. Let |contextId| be params["context"].
+1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
+1. Let |deviceAddress| be |params|[`"address"`].
+1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
+1. If |simulatedBluetoothAdapter| is empty, return [=error=] with [=error code=] [=invalid argument=].
+1. Let |deviceMapping| be |simulatedBluetoothAdapter|'s <a>simulated Bluetooth device mapping</a>.
+1. If |deviceMapping|[|deviceAddress|] [=map/exists=], let |simulatedDevice| be |deviceMapping|[|deviceAddress|].
+    Otherwise, return [=error=] with [=error code=] [=invalid argument=].
+1. Let |simulatedDeviceInstance| be the result of <a>get the <code>BluetoothDevice</code> representing</a>
+    |simulatedDevice| inside |navigable|'s <a>active window</a>'s <a spec=HTML>associated <code>Navigator</code></a>'s
+    [=associated Bluetooth=].
+1. Let |gatt| be |simulatedDeviceInstance|.{{[[gatt]]}}.
+1. For each |promise| in |gatt|.{{[[activeAlgorithms]]}}, [=resolve=] |promise| with |params|.
+
+</div>
+
+<div class="example">
+A [=local end=] could simulate a device gatt connection response by sending the following message:
+
+<pre highlight="json">
+{
+  "method": "bluetooth.simulateGattResponse",
+  "params": {
+    "context": "cxt-d03fdd81",
+    "address": "09:09:09:09:09:09",
+    "type": "connection"
+  }
+}
+</pre>
+</div>
+
+<div class="example">
+A [=local end=] could simulate a device gatt service discovery response by sending the following message:
+
+<pre highlight="json">
+{
+  "method": "bluetooth.simulateGattResponse",
+  "params": {
+    "context": "cxt-d03fdd81",
+    "address": "09:09:09:09:09:09",
+    "type": "discovery"
+  }
+}
+</pre>
+</div>
+
 ### Events ### {#bidi-events}
 
 #### The bluetooth.requestDevicePromptUpdated Event #### {#bluetooth-requestdevicepromptupdated-event}
@@ -5453,10 +5547,41 @@ To <dfn>trigger a prompt updated event</dfn> given a [=navigable=] |navigable|, 
 1. Let |prompt| be the [=device prompt=] (|promptId|, |devices|).
 1. Let |serialized devices| be the result of [=serialize prompt devices=] with |prompt|.
 1. Set [=map of navigables to device prompts=][|navigableId|] to |prompt|.
-1. Let |params| be a [=map=] matching the <code>bluetooth.RequestDevicePromptUpdatedParameters</code> production  with the <code>context</code> field set to |navigableId|, the <code>prompt</code> field set to |promptId|, and the <code>devices</code> field set to |serialized devices|.
+1. Let |params| be a [=map=] matching the <code>bluetooth.RequestDevicePromptUpdatedParameters</code> production with the <code>context</code> field set to |navigableId|, the <code>prompt</code> field set to |promptId|, and the <code>devices</code> field set to |serialized devices|.
 1. Let |body| be a [=map=] matching the <code>bluetooth.RequestDevicePromptUpdated</code> production, with the <code>params</code> field set to |params|.
 1. Let |related navigables| be a [=/set=] containing |navigable|.
 1. For each |session| in the [=set of sessions for which an event is enabled=] given "<code>bluetooth.requestDevicePromptUpdated</code>" and |related navigables|:
+    1. [=Emit an event=] with |session| and |body|.
+
+</div>
+
+#### The bluetooth.gattEventGenerated Event #### {#bluetooth-gatteventgenerated-event}
+
+<pre highlight="cddl" class="cddl local-cddl">
+bluetooth.GattEventGenerated = (
+   method: "bluetooth.gattEventGenerated",
+   params: bluetooth.GattEventGeneratedParameters
+)
+
+bluetooth.GattEventGeneratedParameters = {
+   context: text,
+   address: text,
+   type: "connection" / "discovery",
+}
+</pre>
+
+<div algorithm="remote end event trigger for bluetooth.GattEventGenerated">
+To <dfn>trigger a gatt event</dfn> given a [=navigable=] |navigable|, a [=Bluetooth device=] |device|, and |type|:
+
+1. Let |navigableId| be |navigable|'s [=navigable id=].
+1. Let |params| be a [=map=] matching the <code>bluetooth.GattEventGeneratedParameters</code> production with the
+    <code>context</code> field set to |navigableId|, the <code>address</code> field set to |device|'s address, and the
+    <code>type</code> field set to |type|.
+1. Let |body| be a [=map=] matching the <code>bluetooth.GattEventGenerated</code> production, with the
+    <code>params</code> field set to |params|.
+1. Let |related navigables| be a [=/set=] containing |navigable|.
+1. For each |session| in the [=set of sessions for which an event is enabled=] given
+    "<code>bluetooth.gattEventGenerated</code>" and |related navigables|:
     1. [=Emit an event=] with |session| and |body|.
 
 </div>

--- a/index.bs
+++ b/index.bs
@@ -2915,20 +2915,24 @@ To <dfn>query the Bluetooth cache</dfn> in a {{BluetoothDevice}} instance
 [=a new promise=] |promise| and run the following steps [=in parallel=]:
 
 1. Let |global| be |deviceObj|'s [=relevant global object=].
-1. If |deviceObj|'s [=Window/navigable=]'s [=navigable/top-level traversable=]'s
+1. If |global|'s [=Window/navigable=]'s [=navigable/top-level traversable=]'s
     <a>simulated Bluetooth adapter</a> is not empty, run the following steps:
-    1. [=Trigger a gatt event=] given |deviceObj|'s [=Window/navigable=], |deviceObj|,
+    1. [=Trigger a gatt event=] given |global|'s [=Window/navigable=], |deviceObj|,
         and <code>"discovery"</code>.
-    1. <a>Upon fulfillment</a> of <var>promise</var> with |params|, run the
-        following steps:
+    1. Let |pendingAutomationPromise| be a [=a new promise=].
+    1. Add |pendingAutomationPromise| to [=this=].{{[[pendingAutomationResponse]]}}.
+    1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |params|,
+        run the following steps:
+        1. Remove |pendingAutomationPromise| from [=this=].{{[[pendingAutomationResponse]]}}.
         1. If |params|[`"type"`] is `discovery` and |params|[`"code"`] is `0`, do the
             following sub-steps:
             1. Let |result| be a new sequence.
             1. Append to |result| the <code>Promise&lt;BluetoothGATT*></code>
                 instance in |context|.{{Bluetooth/[[attributeInstanceMap]]}} matching the
                 description.
-            1. Return the result of [=waiting for all=] elements of |result|.
-        1. Otherwise, throw a {{NetworkError}}.
+            1. [=resolve=] |promise| with the result of [=waiting for all=] elements of
+                |result|.
+        1. Otherwise,  [=reject=] |promise| with a {{NetworkError}}.
     1. Abort these steps.
 1. [=Populate the Bluetooth cache=] with entries matching the description.
 1. If the previous step returns an error, [=queue a global task=] on the
@@ -3126,6 +3130,14 @@ slots</a> described in the following table:
       tell whether its <a>realm</a> was ever disconnected while it was running.
     </td>
   </tr>
+  <tr>
+    <td><dfn>\[[pendingAutomationResponse]]</dfn></td>
+    <td><code>new {{Set}}()</code></td>
+    <td>
+      Contains a {{Promise}} corresponding to each algorithm that is waiting for
+      the automation script to provide a response.
+    </td>
+  </tr>
 </table>
 
 <div algorithm="BluetoothRemoteGATTServer connect">
@@ -3144,18 +3156,20 @@ method, when invoked, MUST perform the following steps:
     and/or give the user a way to retry failed operations.
 1. Let |promise| be [=a new promise=].
 1. Add |promise| to [=this=].{{[[activeAlgorithms]]}}.
-1. If [=this=]'s [=Window/navigable=]'s
+1. If |global|'s [=Window/navigable=]'s
     [=navigable/top-level traversable=]'s <a>simulated Bluetooth adapter</a> is
     not empty, run the following steps:
-    1. [=Trigger a gatt event=] given [=this=]'s [=Window/navigable=],
+    1. [=Trigger a gatt event=] given |global|'s [=Window/navigable=],
         [=this=].{{BluetoothRemoteGATTServer/device}}, and <code>"connect"</code>.
-    1. <a>Upon fulfillment</a> of <var>promise</var> with |params|, run the
-        following steps:
+    1. Let |pendingAutomationPromise| be a [=a new promise=].
+    1. Add |pendingAutomationPromise| to [=this=].{{[[pendingAutomationResponse]]}}.
+    1. <a>Upon fulfillment</a> of |pendingAutomationPromise| with |params|,
+        run the following steps:
         1. If |params|[`"type"`] is `connection` and |params|[`"code"`] is `0`,
             do the following sub-steps:
             1. Set [=this=].{{BluetoothRemoteGATTServer/connected}} to `true`.
-            1. return [=this=].
-        1. Otherwise, throw a {{NetworkError}}.
+            1. [=Resolve=] |promise| with [=this=].
+        1. Otherwise, [=reject=] |promise| with  {{NetworkError}}.
     1. Return |promise|.
 1. Run the following steps [=in parallel=]:
     1. If [=this=].{{BluetoothRemoteGATTServer/device}}.{{[[representedDevice]]}}
@@ -5408,7 +5422,7 @@ bluetooth.SimulateAdvertisementScanEntryParameters = {
 <div algorithm="remote end steps for bluetooth.simulateAdvertisement">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be params["context"].
+1. Let |contextId| be |params|["context"].
 1. Let |topLevelNavigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. If |topLevelNavigable| is not a [=navigable/top-level traversable=], return [=error=] with [=error code=] [=invalid argument=].
 1. Let |scanEntry| be |params|[`"scanEntry"`].
@@ -5477,7 +5491,7 @@ bluetooth.SimulateGattResponseParameters = {
 <div algorithm="remote end steps for bluetooth.simulateGattResponse">
 The [=remote end steps=] with command parameters |params| are:
 
-1. Let |contextId| be params["context"].
+1. Let |contextId| be |params|["context"].
 1. Let |navigable| be the result of [=trying=] to [=get a navigable=] with |contextId|.
 1. Let |deviceAddress| be |params|[`"address"`].
 1. Let |simulatedBluetoothAdapter| be |navigable|'s <a>simulated Bluetooth adapter</a>.
@@ -5489,8 +5503,7 @@ The [=remote end steps=] with command parameters |params| are:
     |simulatedDevice| inside |navigable|'s <a>active window</a>'s <a spec=HTML>associated <code>Navigator</code></a>'s
     [=associated Bluetooth=].
 1. Let |gatt| be |simulatedDeviceInstance|.{{[[gatt]]}}.
-1. For each |promise| in |gatt|.{{[[activeAlgorithms]]}}, [=resolve=] |promise| with |params| and remove |promise|
-    from |gatt|.{{[[activeAlgorithms]]}}.
+1. For each |promise| in |gatt|.{{[[pendingAutomationResponse]]}}, [=resolve=] |promise| with |params|.
 
 </div>
 


### PR DESCRIPTION
Add new WebDriver Bidi command and event for Web Bluetooth automation:
- bluetooth.gattConnectionAttempted: Event upon GATT connection attempt.
- bluetooth.simulateGattConnectionResponse: For simulating the response for a GATT connection attempt.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/650.html" title="Last updated on Apr 16, 2025, 4:42 AM UTC (34b4996)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/650/c845e58...chengweih001:34b4996.html" title="Last updated on Apr 16, 2025, 4:42 AM UTC (34b4996)">Diff</a>