### PR TITLE
[WebDriver BiDi] Add CDDL for Events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5569,6 +5569,13 @@ A [=local end=] could simulate device GATT disconnection by sending the followin
 
 ### Events ### {#bidi-events}
 
+<pre highlight="cddl" class="cddl remote-cddl local-cddl">
+BluetoothEvent = (
+  bluetooth.RequestDevicePromptUpdated //
+  bluetooth.GattConnectionAttempted //
+)
+</pre>
+
 #### The bluetooth.requestDevicePromptUpdated Event #### {#bluetooth-requestdevicepromptupdated-event}
 
 <pre highlight="cddl" class="cddl local-cddl">


### PR DESCRIPTION
Similar to the command BiDi modules export a CDDL with all the Events they have - https://w3c.github.io/webdriver-bidi/#module-contexts-events:~:text=BrowsingContextEvent%20%3D%20(


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/web-bluetooth/pull/653.html" title="Last updated on Apr 25, 2025, 3:11 PM UTC (2883df4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/653/d940d56...Lightning00Blade:2883df4.html" title="Last updated on Apr 25, 2025, 3:11 PM UTC (2883df4)">Diff</a>