### PR TITLE
Fix BetoothCommand CDDL parsing error

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5191,9 +5191,9 @@ BluetoothCommand = (
   bluetooth.SimulateGattDisconnection //
   bluetooth.SimulateService //
   bluetooth.SimulateCharacteristic //
-  bluetooth.simulateCharacteristicResponse //
+  bluetooth.SimulateCharacteristicResponse //
   bluetooth.SimulateDescriptor //
-  bluetooth.simulateDescriptorResponse //
+  bluetooth.SimulateDescriptorResponse //
 )
 </pre>
 


### PR DESCRIPTION
This fix the [error](https://github.com/GoogleChromeLabs/chromium-bidi/actions/runs/14833916200/job/41641067859) in [chromium-bidi](https://github.com/GoogleChromeLabs/chromium-bidi), which is caused by:



```
error: parser errors
   ┌─ input:41:3
   │
41 │   bluetooth.simulateCharacteristicResponse //
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing definition for rule bluetooth.simulateCharacteristicResponse
42 │   bluetooth.SimulateDescriptor //
43 │   bluetooth.simulateDescriptorResponse //
   │   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ missing definition for rule bluetooth.simulateDescriptorResponse

Error: incremental parsing error

```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/656.html" title="Last updated on May 5, 2025, 11:56 PM UTC (dd24fe9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/656/75e1dd5...chengweih001:dd24fe9.html" title="Last updated on May 5, 2025, 11:56 PM UTC (dd24fe9)">Diff</a>