### PR TITLE
[WebDriver BiDi] Fix CDDL for events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5934,7 +5934,7 @@ with data for a descriptor read operation by sending the following message:
 <pre highlight="cddl" class="cddl remote-cddl local-cddl">
 BluetoothEvent = (
   bluetooth.RequestDevicePromptUpdated //
-  bluetooth.GattConnectionAttempted //
+  bluetooth.GattConnectionAttempted
 )
 </pre>
 


### PR DESCRIPTION
Small fix for the CDDL, the last entry needs to not have `//`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/web-bluetooth/pull/658.html" title="Last updated on May 19, 2025, 9:31 AM UTC (e30df9d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/658/7127a3f...Lightning00Blade:e30df9d.html" title="Last updated on May 19, 2025, 9:31 AM UTC (e30df9d)">Diff</a>