### PR TITLE
Properly set properties in bluetooth.simulateCharacteristic

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5023,8 +5023,8 @@ A <dfn>simulated GATT characteristic</dfn> is a software defined [=Characteristi
 <a>simulated GATT service</a>, has a property of <a>UUID</a>, a property of <a>Characteristic Properties</a>,
 and is known-present in the <a>Bluetooth cache</a>.
 
-A <dfn>simulated GATT characteristic properties</dfn> is a software defined [=Characteristic Properties=] that belongs to a
-<a>simulated GATT characteristic</a> and is known-present in the <a>Bluetooth cache</a>.
+<dfn>Simulated GATT characteristic properties</dfn> are software defined [=Characteristic Properties=] that belong to a
+<a>simulated GATT characteristic</a> and are known-present in the <a>Bluetooth cache</a>.
 
 Issue: CDDL snippetes use the "text" type instead of
 "browsingContext.BrowsingContext" to allow indepedent programmatic
@@ -5722,8 +5722,8 @@ The [=remote end steps=] with command parameters |params| are:
 1. If |params|[`"type"`] is `"add"`:
     1. If |characteristicMapping|[|characteristicUuid|] [=map/exists=], return [=error=] with
         [=error code=] [=invalid element state=].
-    1. If |params|[`"characteristicProperties"`] does not [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
-    1. Let |simulatedGattCharacteristicProperties| be a new <a>simulated GATT characteristic properties</a> and run the following steps:
+    1. If |params|[`"characteristicProperties"`] does not [=map/exist=], return [=error=] with [=error code=] [=invalid argument=].
+    1. Let |simulatedGattCharacteristicProperties| be new <a>simulated GATT characteristic properties</a> and run the following steps:
         1. Let |properties| be |params|[`"characteristicProperties"`].
         1. If |properties|[`"broadcast"`] [=map/exists=], set |simulatedGattCharacteristicProperties|'s `Broadcast` bit if
             |properties|[`"broadcast"`] is `true`.


### PR DESCRIPTION
This PR fixes the issue in the automation command `bluetooth.simulateCharacteristic` that it doesn't set the simulated characteristic properties properly.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/660.html" title="Last updated on Jul 21, 2025, 10:10 PM UTC (50d794b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/660/94157f9...chengweih001:50d794b.html" title="Last updated on Jul 21, 2025, 10:10 PM UTC (50d794b)">Diff</a>