### PR TITLE
Algorithms for bluetooth.descriptor commands

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5825,7 +5825,7 @@ The [=remote end steps=] with command parameters |params| are:
         and add a mapping from |simulatedGattService| to the resulting {{Promise}} in
         |simulatedDeviceInstance|.{{[[context]]}}.{{Bluetooth/[[attributeInstanceMap]]}}.
     1. Return [=success=] with data `null`.
-1. Else if |params|[`"type"`] is `"remove"`:
+1. If |params|[`"type"`] is `"remove"`:
     1. If |serviceMapping|[|uuid|] [=map/exists=], let |simulatedGattService| be |serviceMapping|[|uuid|].
     1. Otherwise, return [=error=] with [=error code=] [=invalid element state=].
     1. Remove |simulatedGattService| from |simulatedDeviceInstance|.{{[[context]]}}.{{Bluetooth/[[attributeInstanceMap]]}}.
@@ -5935,7 +5935,7 @@ The [=remote end steps=] with command parameters |params| are:
         and add a mapping from |simulatedGattCharacteristic| to the resulting {{Promise}} in
         |simulatedDeviceInstance|.{{[[context]]}}.{{Bluetooth/[[attributeInstanceMap]]}}.
     1. Return [=success=] with data `null`.
-1. Else if |params|[`"type"`] is `"remove"`:
+1. If |params|[`"type"`] is `"remove"`:
     1. If |params|[`"characteristicProperties"`] [=map/exists=], return [=error=] with [=error code=] [=invalid argument=].
     1. If |characteristicMapping|[|characteristicUuid|] [=map/exists=], let |simulatedGattCharacteristic|
         be |characteristicMapping|[|characteristicUuid|].
@@ -6125,7 +6125,7 @@ bluetooth.SimulateDescriptorParameters = {
         and add a mapping from |simulatedGattDescriptor| to the resulting {{Promise}} in
         |simulatedDeviceInstance|.{{[[context]]}}.{{Bluetooth/[[attributeInstanceMap]]}}.
     1. Return [=success=] with data `null`.
-1. Else if |params|[`"type"`] is `"remove"`:
+1. If |params|[`"type"`] is `"remove"`:
     1. If |descriptorMapping|[|descriptorUuid|] [=map/exists=], let |simulatedGattDescriptor|
         be |descriptorMapping|[|descriptorUuid|].
     1. Otherwise, return [=error=] with [=error code=] [=invalid element state=].


### PR DESCRIPTION
Complete the algorithms for `bluetooth.SimulateDescriptorResponse`, `bluetooth.DescriptorEventGenerated`, and `bluetooth.simulateDescriptor`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/chengweih001/web-bluetooth/pull/662.html" title="Last updated on Aug 5, 2025, 7:28 AM UTC (0a2c94d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/662/e4f357d...chengweih001:0a2c94d.html" title="Last updated on Aug 5, 2025, 7:28 AM UTC (0a2c94d)">Diff</a>