### PR TITLE
[WebDriver BiDi] Fix CDDL parsing 

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -5382,7 +5382,7 @@ BluetoothCommand = (
   bluetooth.SimulateCharacteristic //
   bluetooth.SimulateCharacteristicResponse //
   bluetooth.SimulateDescriptor //
-  bluetooth.SimulateDescriptorResponse //
+  bluetooth.SimulateDescriptorResponse
 )
 </pre>
 


### PR DESCRIPTION
Downstream this creates an issue, as the last entry should not have the `//`.
While our parser handles is gracefully it does add extra unwanted type declarations.

Similar to https://github.com/WebBluetoothCG/web-bluetooth/pull/658


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/Lightning00Blade/web-bluetooth/pull/665.html" title="Last updated on Sep 14, 2025, 5:53 PM UTC (bd6ae28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WebBluetoothCG/web-bluetooth/665/4706ca3...Lightning00Blade:bd6ae28.html" title="Last updated on Sep 14, 2025, 5:53 PM UTC (bd6ae28)">Diff</a>